### PR TITLE
Add some fields that would be of great value for ArduPilot applications:

### DIFF
--- a/src/erb.c
+++ b/src/erb.c
@@ -189,7 +189,7 @@ static void buildstat(char *payload, struct erb_stat status, const uint32_t time
     status.weekGPS = week;
     status.fixType = fixType;
     status.fixStatus = fixStatus;
-    status.numSV = sol->ns;
+    status.numSV = sol->nSV;
 
     /* Introduced in ERB version 0.2.0 */
     if (sol->type == 0) { /* xyz-ecef */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1817,7 +1817,7 @@ EXPORT int outnmea_gsv(unsigned char *buff, const sol_t *sol,
 extern int outnmea_vtg(unsigned char *buff, const sol_t *sol);
 extern int outnmea_gst(unsigned char *buff, const sol_t *sol,
                        const ssat_t *ssat);
-EXPORT int outerb(unsigned char *buff, const sol_t *sol);
+EXPORT int outerb(unsigned char *buff, const sol_t *sol, const double *rb);
 
 /* google earth kml converter ------------------------------------------------*/
 EXPORT int convkml(const char *infile, const char *outfile, gtime_t ts,

--- a/src/solution.c
+++ b/src/solution.c
@@ -1632,7 +1632,7 @@ extern int outsols(unsigned char *buff, const sol_t *sol, const double *rb,
         case SOLF_ENU:  p+=outenu(p,s,sol,rb,opt); break;
         case SOLF_NMEA: p+=outnmea_rmc(p,sol);
                         p+=outnmea_gga(p,sol);     break;
-        case SOLF_ERB:  p+=outerb(p,sol);          break;
+        case SOLF_ERB:  p+=outerb(p,sol,rb);       break;
     }
     return p-buff;
 }


### PR DESCRIPTION
* GPS leap seconds
* NED coordinates of rover relative to base (can be used to calculate baseline distance)
* Age of the corrections in deciseconds (0xFFFF indicates invalid)
* AR ratio

Added comments where applicable
Increment ERB protocol version

The ardupilot code can parse the version information and find out automaticaly how to intrepret the extra fields.  I'm on the ArduPilot development team and I'll do those changes.

The final goal of this thing is to not have to get Wi-Fi connection to reach-rover just to see if it is working like it should. It should pass this extendedstatus information to the ground station. This allows for one less software window.