### PR TITLE
rtkrcv: skip outdated base observations

### DIFF
--- a/app/rtkrcv/rtkrcv.c
+++ b/app/rtkrcv/rtkrcv.c
@@ -833,9 +833,11 @@ static void probserv(vt_t *vt, int nf)
     trace(4,"probserv:\n");
 
     rtksvrlock(&svr);
+    /* load rover obs data */
     for (i=0;i<svr.obs[0][0].n&&n<MAXOBS*2;i++) {
         obs[n++]=svr.obs[0][0].data[i];
     }
+    /* load base obs data */
     for (i=0;i<svr.obs[1][0].n&&n<MAXOBS*2;i++) {
         obs[n++]=svr.obs[1][0].data[i];
     }


### PR DESCRIPTION
to address the issue of obsolete data displaying when base corrections stop coming
note: needs to check