### PR TITLE
rtkpos.c: reset phase-bias if phase residual is beyond a threshold

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -119,6 +119,11 @@ EXPORT opt_t sysopts[]={
     {"smooth-window",   1,  (void *)&prcopt_.smoothing_window,"s"},
     {"smooth-varratio", 1,  (void *)&prcopt_.smoothing_varratio,""},
     
+    {"resid-mode",      3,  (void *)&prcopt_.residual_mode,SWTOPT},
+    {"resid-reset_fix", 1,  (void *)&prcopt_.residual_reset_fix,"m"},
+    {"resid-reset_float",1, (void *)&prcopt_.residual_reset_float,"m"},
+    {"resid-block_fix_sat",1,(void *)&prcopt_.residual_block_fix_sat, "m"},
+    
     {"out-solformat",   3,  (void *)&solopt_.posf,       SOLOPT },
     {"out-outhead",     3,  (void *)&solopt_.outhead,    SWTOPT },
     {"out-outopt",      3,  (void *)&solopt_.outopt,     SWTOPT },

--- a/src/options.c
+++ b/src/options.c
@@ -120,6 +120,7 @@ EXPORT opt_t sysopts[]={
     {"smooth-varratio", 1,  (void *)&prcopt_.smoothing_varratio,""},
     
     {"resid-mode",      3,  (void *)&prcopt_.residual_mode,SWTOPT},
+    {"resid-maxiter",   0,  (void *)&prcopt_.residual_maxiter,""},
     {"resid-reset_fix", 1,  (void *)&prcopt_.residual_reset_fix,"m"},
     {"resid-reset_float",1, (void *)&prcopt_.residual_reset_float,"m"},
     {"resid-block_fix_sat",1,(void *)&prcopt_.residual_block_fix_sat, "m"},

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -207,6 +207,7 @@ const prcopt_t prcopt_default={ /* defaults processing options */
     {100.0,0.003,0.003,0.0,1.0}, /* err[] */
 
     0, 100, 0.2,                /* smooth-mode, smooth-window, smooth-varratio */
+    0, 0.2, 0.5, 0.05,          /* resid-mode, resid-reset_fix, resid-reset_float, resid-block_fix_sat */
 
     {30.0,0.03,0.3},            /* std[] */
     {1E-4,1E-3,1E-4,1E-1,1E-2,0.0}, /* prn[] */

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -207,7 +207,7 @@ const prcopt_t prcopt_default={ /* defaults processing options */
     {100.0,0.003,0.003,0.0,1.0}, /* err[] */
 
     0, 100, 0.2,                /* smooth-mode, smooth-window, smooth-varratio */
-    0, 0.2, 0.5, 0.05,          /* resid-mode, resid-reset_fix, resid-reset_float, resid-block_fix_sat */
+    0, 5, 0.2, 0.5, 0.05,       /* resid-mode, resid-maxiter, resid-reset_fix, resid-reset_float, resid-block_fix_sat */
 
     {30.0,0.03,0.3},            /* std[] */
     {1E-4,1E-3,1E-4,1E-1,1E-2,0.0}, /* prn[] */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -45,6 +45,7 @@
 #include <math.h>
 #include <time.h>
 #include <ctype.h>
+#include <assert.h>
 #ifdef WIN32
 #include <winsock2.h>
 #include <windows.h>
@@ -1124,10 +1125,15 @@ typedef struct {        /* processing options type */
                         /* [1-3]:error factor a/b/c of phase (m) */
                         /* [4]:doppler frequency (hz) */
     
-    int    smoothing_mode;   /* is code smoothing carried out? (0:off,1:on) */
-    double smoothing_window; /* smoothing window (s)  */
+    int    smoothing_mode;     /* is code smoothing carried out? (0:off,1:on) */
+    double smoothing_window;   /* smoothing window (s)  */
     double smoothing_varratio; /* asymptotic factor of code variance decrease due to smoothing */
 
+    int    residual_mode;         /* on/off */
+    double residual_reset_fix;    /* carrier-phase residual threshold to reset phase-bias when solution status is FIX (m) */
+    double residual_reset_float;  /* carrier-phase residual threshold to reset phase-bias when solution status is FLOAT (m) */
+    double residual_block_fix_sat;/* carrier-phase residual threshold to prevent using a satellite for ambiguity resolution (m) */
+    
     double std[3];      /* initial-state std [0]bias,[1]iono [2]trop */
     double prn[6];      /* process-noise std [0]bias,[1]iono [2]trop [3]acch [4]accv [5] pos */
     double sclkstab;    /* satellite clock stability (sec/sec) */
@@ -1243,6 +1249,8 @@ typedef struct {        /* satellite status type */
     unsigned char snr [NFREQ]; /* signal strength (0.25 dBHz) */
     unsigned char fix [NFREQ]; /* ambiguity fix flag (1:fix,2:float,3:hold) */
     unsigned char slip[NFREQ]; /* cycle-slip flag */
+    unsigned char to_reset[NFREQ]; /* flag signalizing the need to reset phase-bias if not 0 */
+    unsigned char no_fix[NFREQ];   /* prevent using satellite for ambiguity resolution if not 0 */
     unsigned char half[NFREQ]; /* half-cycle valid flag */
     int lock [NFREQ];   /* lock counter of phase */
     unsigned int outc [NFREQ]; /* obs outage counter of phase */

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1130,6 +1130,7 @@ typedef struct {        /* processing options type */
     double smoothing_varratio; /* asymptotic factor of code variance decrease due to smoothing */
 
     int    residual_mode;         /* on/off */
+    int    residual_maxiter;      /* max number of iterations */ 
     double residual_reset_fix;    /* carrier-phase residual threshold to reset phase-bias when solution status is FIX (m) */
     double residual_reset_float;  /* carrier-phase residual threshold to reset phase-bias when solution status is FLOAT (m) */
     double residual_block_fix_sat;/* carrier-phase residual threshold to prevent using a satellite for ambiguity resolution (m) */
@@ -1244,10 +1245,10 @@ typedef struct {        /* satellite status type */
     double azel[2];     /* azimuth/elevation angles {az,el} (rad) */
     double resp[NFREQ]; /* residuals of pseudorange (m) */
     double resc[NFREQ]; /* residuals of carrier-phase (m) */
-	double icbias[NFREQ];  /* glonass IC bias (cycles) */
+    double icbias[NFREQ];  /* glonass IC bias (cycles) */
     unsigned char vsat[NFREQ]; /* valid satellite flag */
     unsigned char snr [NFREQ]; /* signal strength (0.25 dBHz) */
-    unsigned char fix [NFREQ]; /* ambiguity fix flag (1:fix,2:float,3:hold) */
+    unsigned char fix [NFREQ]; /* ambiguity fix flag (1:float,2:fix,3:hold) */
     unsigned char slip[NFREQ]; /* cycle-slip flag */
     unsigned char to_reset[NFREQ]; /* flag signalizing the need to reset phase-bias if not 0 */
     unsigned char no_fix[NFREQ];   /* prevent using satellite for ambiguity resolution if not 0 */


### PR DESCRIPTION
New config options added:
// on/off the feature
resid-mode        =on           # (0:off,1:on)
//max number of iterations
resid-maxiter     =5
// threshold to reset phase-bias when solution status is FIX
resid-reset_fix   =0.2          # (m)
// threshold to reset phase-bias when solution status is FLOAT
resid-reset_float =0.5          # (m)
// threshold to prevent using a satellite for ambiguity resolution
resid-block_fix_sat =0.05       # (m)