### PR TITLE
rtksvr.c: provide option to use base observations from different epochs

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -119,6 +119,8 @@ EXPORT opt_t sysopts[]={
     {"smooth-window",   1,  (void *)&prcopt_.smoothing_window,"s"},
     {"smooth-varratio", 1,  (void *)&prcopt_.smoothing_varratio,""},
     
+    {"base-multi_epoch",3,  (void *)&prcopt_.base_multi_epoch,SWTOPT},
+    
     {"out-solformat",   3,  (void *)&solopt_.posf,       SOLOPT },
     {"out-outhead",     3,  (void *)&solopt_.outhead,    SWTOPT },
     {"out-outopt",      3,  (void *)&solopt_.outopt,     SWTOPT },

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -207,6 +207,8 @@ const prcopt_t prcopt_default={ /* defaults processing options */
     {100.0,0.003,0.003,0.0,1.0}, /* err[] */
 
     0, 100, 0.2,                /* smooth-mode, smooth-window, smooth-varratio */
+    
+    0,                          /* base-multi_epoch */ 
 
     {30.0,0.03,0.3},            /* std[] */
     {1E-4,1E-3,1E-4,1E-1,1E-2,0.0}, /* prn[] */


### PR DESCRIPTION
compilation of base obs contains the most recent data separately for
each satellite system specified; to address the issue of 'blinking' data

New config options added:
// on/off the feature
base-multi_epoch =on # (0:off,1:on)