### PR TITLE
rtksvr.c: unite GPS, QZSS and SBAS satellite groups in obs_queue record

### DIFF
--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -532,11 +532,11 @@ static void navsys_convert_binary_to_array(int sys_binary, int *sys_array, int *
     if ( sys_binary & SYS_GPS ) { sys_array[*nsys] = SYS_GPS; (*nsys)++; }
     if ( sys_binary & SYS_GLO ) { sys_array[*nsys] = SYS_GLO; (*nsys)++; }
     if ( sys_binary & SYS_GAL ) { sys_array[*nsys] = SYS_GAL; (*nsys)++; }
+    if ( sys_binary & SYS_QZS ) { sys_array[*nsys] = SYS_QZS; (*nsys)++; }
     if ( sys_binary & SYS_CMP ) { sys_array[*nsys] = SYS_CMP; (*nsys)++; }
     if ( sys_binary & SYS_IRN ) { sys_array[*nsys] = SYS_IRN; (*nsys)++; }
     if ( sys_binary & SYS_LEO ) { sys_array[*nsys] = SYS_LEO; (*nsys)++; }
     if ( sys_binary & SYS_SBS ) { sys_array[*nsys] = SYS_SBS; (*nsys)++; }
-    if ( sys_binary & SYS_QZS ) { sys_array[*nsys] = SYS_QZS; (*nsys)++; }
     
     assert( *nsys <= MAXSYS );
 }


### PR DESCRIPTION
unite GPS, QZSS and SBAS satellite group since they are considered as
one group in rtkpos.c; to resolve the issue of getting wrong position
while processing GPS, SBAS and QZSS satellites from different epochs