### PR TITLE
app: convbin: fix bug wtih wrong indicator for counting states in convbin status

### DIFF
--- a/src/convrnx.c
+++ b/src/convrnx.c
@@ -955,8 +955,8 @@ static void convobs(FILE **ofp, rnxopt_t *opt, strfile_t *str, int *staid,
     }
     /* output rinex obs */
 	outrnxobsb(ofp[0],opt,str->obs->data,str->obs->n,str->obs->flag);
-    /* n[8] - count of events converted to rinex */
-    if (str->obs->flag == 5) n[8]++;
+    /* n[10] - count of events converted to rinex */
+    if (str->obs->flag == 5) n[10]++;
  	/* set to zero flag for the next iteration (initialization) */
  	str->obs->flag = 0;
     


### PR DESCRIPTION
Indicator for timemark counter was replaced with indicator for sbas records counter.