### PR TITLE
src: rtksvr.c: fix bug with checking stream number from PR #84

### DIFF
--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -980,7 +980,7 @@ static void *rtksvrthread(void *arg)
 
             /* don't connect if single solution is required but absent */
             if (svr->stream[stream_number].type == STR_NTRIPCLI && ntrip_single_required) 
-                if (i == BASE_STREAM && svr->rtk.sol.stat == SOLQ_NONE) 
+                if (stream_number == BASE_STREAM && svr->rtk.sol.stat == SOLQ_NONE) 
                     continue;
 
             /* read receiver raw/rtcm data from input stream */


### PR DESCRIPTION
In PR #84  iteration variable 'i' was replaced with 'stream_number' except one appearance.