### PR TITLE
Fix NMEA messages in accordance to NMEA-0183 official specification

### DIFF
--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -2144,6 +2144,11 @@ static int relpos(rtk_t *rtk, const obsd_t *obs, int nu, int nr,
             rtk->sol.rr[i]=rtk->xa[i];
             rtk->sol.qr[i]=(float)rtk->Pa[i+i*rtk->na];
         }
+        if (rtk->opt.dynamics) {
+            for (i = 3; i < 6; i++) {
+                rtk->sol.rr[i] = rtk->xa[i];
+            }
+        }
         rtk->sol.qr[3]=(float)rtk->Pa[1];
         rtk->sol.qr[4]=(float)rtk->Pa[1+2*rtk->na];
         rtk->sol.qr[5]=(float)rtk->Pa[2];
@@ -2152,6 +2157,11 @@ static int relpos(rtk_t *rtk, const obsd_t *obs, int nu, int nr,
         for (i=0;i<3;i++) {
             rtk->sol.rr[i]=rtk->x[i];
             rtk->sol.qr[i]=(float)rtk->P[i+i*rtk->nx];
+        }
+        if (rtk->opt.dynamics) {
+            for (i = 3; i < 6; i++) {
+                rtk->sol.rr[i] = rtk->x[i];
+            }
         }
         rtk->sol.qr[3]=(float)rtk->P[1];
         rtk->sol.qr[4]=(float)rtk->P[1+2*rtk->nx];

--- a/src/solution.c
+++ b/src/solution.c
@@ -1356,7 +1356,6 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
 }
 /* output solution in the form of nmea VTG sentence --------------------------*/
 extern int outnmea_vtg(unsigned char *buff, const sol_t *sol) {
-    static double dirp = 0.0;
     double pos[3], enuv[3], vel, dir;
     char *p = (char *) buff, *q, sum, dir_str[10] = "";
     char posmode;

--- a/src/solution.c
+++ b/src/solution.c
@@ -1114,15 +1114,14 @@ static int outenu(unsigned char *buff, const char *s, const sol_t *sol,
 /* output solution in the form of nmea RMC sentence --------------------------*/
 extern int outnmea_rmc(unsigned char *buff, const sol_t *sol)
 {
-    static double dirp=0.0;
     gtime_t time;
-    double ep[6],pos[3],enuv[3],dms1[3],dms2[3],vel,dir,amag=0.0;
-    char *p=(char *)buff,*q,sum,*emag="E";
+    double ep[6],pos[3],enuv[3],dms1[3],dms2[3],vel,dir;
+    char *p=(char *)buff,*q,sum,dir_str[10] = "";
     
     trace(3,"outnmea_rmc:\n");
     
     if (sol->stat<=SOLQ_NONE) {
-        p+=sprintf(p,"$GPRMC,,,,,,,,,,,,");
+        p+=sprintf(p,"$GNRMC,,,,,,,,,,,,");
         for (q=(char *)buff+1,sum=0;*q;q++) sum^=*q;
         p+=sprintf(p,"*%02X%c%c",sum,0x0D,0x0A);
         return p-(char *)buff;
@@ -1132,19 +1131,19 @@ extern int outnmea_rmc(unsigned char *buff, const sol_t *sol)
     time2epoch(time,ep);
     ecef2pos(sol->rr,pos);
     ecef2enu(pos,sol->rr+3,enuv);
-    vel=norm(enuv,3);
-    if (vel>=1.0) {
+    vel=norm(enuv,2);
+    if (vel>=0.5) {
         dir=atan2(enuv[0],enuv[1])*R2D;
         if (dir<0.0) dir+=360.0;
-        dirp=dir;
+        sprintf(dir_str, "%4.2f", dir);
     }
-    else dir=dirp;
+
     deg2dms(fabs(pos[0])*R2D,dms1,7);
     deg2dms(fabs(pos[1])*R2D,dms2,7);
-    p+=sprintf(p,"$GPRMC,%02.0f%02.0f%05.2f,A,%02.0f%010.7f,%s,%03.0f%010.7f,%s,%4.2f,%4.2f,%02.0f%02.0f%02d,%.1f,%s,%s",
+    p+=sprintf(p,"$GNRMC,%02.0f%02.0f%05.2f,A,%02.0f%010.7f,%s,%03.0f%010.7f,%s,%4.2f,%s,%02.0f%02.0f%02d,,,%s",
                ep[3],ep[4],ep[5],dms1[0],dms1[1]+dms1[2]/60.0,pos[0]>=0?"N":"S",
-               dms2[0],dms2[1]+dms2[2]/60.0,pos[1]>=0?"E":"W",vel/KNOT2M,dir,
-               ep[2],ep[1],(int)ep[0]%100,amag,emag,
+               dms2[0],dms2[1]+dms2[2]/60.0,pos[1]>=0?"E":"W",vel/KNOT2M,dir_str,
+               ep[2],ep[1],(int)ep[0]%100,
                sol->stat==SOLQ_DGPS||sol->stat==SOLQ_FLOAT||sol->stat==SOLQ_FIX?"D":"A");
     for (q=(char *)buff+1,sum=0;*q;q++) sum^=*q; /* check-sum */
     p+=sprintf(p,"*%02X%c%c",sum,0x0D,0x0A);
@@ -1154,14 +1153,15 @@ extern int outnmea_rmc(unsigned char *buff, const sol_t *sol)
 extern int outnmea_gga(unsigned char *buff, const sol_t *sol)
 {
     gtime_t time;
-    double h,ep[6],pos[3],dms1[3],dms2[3],dop=1.0;
+    double h,ep[6],pos[3],dms1[3],dms2[3],hdop;
     int solq;
     char *p=(char *)buff,*q,sum;
     
     trace(3,"outnmea_gga:\n");
-    
+
+    hdop = sol->dop[2];
     if (sol->stat<=SOLQ_NONE) {
-        p+=sprintf(p,"$GPGGA,,,,,,,,,,,,,,");
+        p+=sprintf(p,"$GNGGA,,,,,,,,,,,,,,");
         for (q=(char *)buff+1,sum=0;*q;q++) sum^=*q;
         p+=sprintf(p,"*%02X%c%c",sum,0x0D,0x0A);
         return p-(char *)buff;
@@ -1175,10 +1175,10 @@ extern int outnmea_gga(unsigned char *buff, const sol_t *sol)
     h=geoidh(pos);
     deg2dms(fabs(pos[0])*R2D,dms1,7);
     deg2dms(fabs(pos[1])*R2D,dms2,7);
-    p+=sprintf(p,"$GPGGA,%02.0f%02.0f%05.2f,%02.0f%010.7f,%s,%03.0f%010.7f,%s,%d,%02d,%.1f,%.3f,M,%.3f,M,%.1f,",
+    p+=sprintf(p,"$GNGGA,%02.0f%02.0f%05.2f,%02.0f%010.7f,%s,%03.0f%010.7f,%s,%d,%02d,%.1f,%.3f,M,%.3f,M,%.1f,",
                ep[3],ep[4],ep[5],dms1[0],dms1[1]+dms1[2]/60.0,pos[0]>=0?"N":"S",
                dms2[0],dms2[1]+dms2[2]/60.0,pos[1]>=0?"E":"W",solq,
-               sol->ns,dop,pos[2]-h,h,sol->age);
+               sol->ns,hdop,pos[2]-h,h,sol->age);
     for (q=(char *)buff+1,sum=0;*q;q++) sum^=*q; /* check-sum */
     p+=sprintf(p,"*%02X%c%c",sum,0x0D,0x0A);
     return p-(char *)buff;
@@ -1282,7 +1282,7 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
         if (sys!=SYS_GPS&&sys!=SYS_SBS) continue;
         if (ssat[sat-1].vs&&ssat[sat-1].azel[1]>0.0) sats[n++]=sat;
     }
-    nmsg=n<=0?0:(n-1)/4+1;
+    nmsg = n/4 + (n%4 > 0 ? 1:0);
     
     for (i=k=0;i<nmsg;i++) {
         s=p;
@@ -1307,7 +1307,7 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
         if (satsys(sat,&prn)!=SYS_GLO) continue;
         if (ssat[sat-1].vs&&ssat[sat-1].azel[1]>0.0) sats[n++]=sat;
     }
-    nmsg=n<=0?0:(n-1)/4+1;
+    nmsg = n/4 + (n%4 > 0 ? 1:0);
     
     for (i=k=0;i<nmsg;i++) {
         s=p;
@@ -1332,7 +1332,7 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
         if (satsys(sat,&prn)!=SYS_GAL) continue;
         if (ssat[sat-1].vs&&ssat[sat-1].azel[1]>0.0) sats[n++]=sat;
     }
-    nmsg=n<=0?0:(n-1)/4+1;
+    nmsg = n/4 + (n%4 > 0 ? 1:0);
     
     for (i=k=0;i<nmsg;i++) {
         s=p;
@@ -1357,24 +1357,25 @@ extern int outnmea_gsv(unsigned char *buff, const sol_t *sol,
 /* output solution in the form of nmea VTG sentence --------------------------*/
 extern int outnmea_vtg(unsigned char *buff, const sol_t *sol) {
     static double dirp = 0.0;
-    double pos[3], enuv[3], vel, dir, amag = 0.0;
-    char *p = (char *) buff, *q, sum, *emag = "E";
+    double pos[3], enuv[3], vel, dir;
+    char *p = (char *) buff, *q, sum, dir_str[10] = "";
     char posmode;
     trace(3, "outnmea_vtg:\n");
     if (sol->stat <= SOLQ_NONE) {
-        p += sprintf(p, "$GPVTG,,,,,,,");
+        p += sprintf(p, "$GNVTG,,,,,,,");
         for (q = (char *) buff + 1, sum = 0; *q; q++) sum ^= *q;
         p += sprintf(p, "*%02X%c%c", sum, 0x0D, 0x0A);
         return p - (char *) buff;
     }
     ecef2pos(sol->rr, pos);
     ecef2enu(pos, sol->rr + 3, enuv);
-    vel = norm(enuv, 3);
-    if (vel >= 1.0) {
+    vel = norm(enuv, 2);
+    if (vel >= 0.5) {
         dir = atan2(enuv[0], enuv[1]) * R2D;
         if (dir < 0.0) dir += 360.0;
-        dirp = dir;
-    } else dir = dirp;
+        sprintf(dir_str, "%4.2f", dir);
+    }
+
     switch (sol->stat) {
         case SOLQ_DR:
             posmode = 'E';
@@ -1386,8 +1387,7 @@ extern int outnmea_vtg(unsigned char *buff, const sol_t *sol) {
             posmode = 'A';
             break;
     }
-    p += sprintf(p, "$GPVTG,%4.2f,T,%4.2f,M,%4.2f,N,%4.2f,K,%c", dir, dir + (*emag == 'E' ? 1 : -1) * amag, vel / KNOT2M,
-                 +vel, posmode);
+    p += sprintf(p, "$GNVTG,%s,T,,M,%4.2f,N,%4.2f,K,%c", dir_str, vel / KNOT2M, vel*3.6, posmode);
     for (q = (char *) buff + 1, sum = 0; *q; q++) sum ^= *q; /* check-sum */
     p += sprintf(p, "*%02X%c%c", sum, 0x0D, 0x0A);
     return p - (char *) buff;
@@ -1415,7 +1415,7 @@ extern int outnmea_gst(unsigned char *buff, const sol_t *sol, const ssat_t *ssat
     }
     time2epoch(time, ep);
     if (sol->stat <= SOLQ_NONE) {
-        p += sprintf(p, "$GPGST,,,,,,,,,");
+        p += sprintf(p, "$GNGST,,,,,,,,,");
         for (q = (char *) buff + 1, sum = 0; *q; q++) sum ^= *q;
         p += sprintf(p, "*%02X%c%c", sum, 0x0D, 0x0A);
         return p - (char *) buff;
@@ -1424,18 +1424,15 @@ extern int outnmea_gst(unsigned char *buff, const sol_t *sol, const ssat_t *ssat
         if (!ssat[sat - 1].vs) {
             continue;
         }
-        if (ssat[sat - 1].resc[0] != 0) {
-            sum_rms += SQR(ssat[sat - 1].resc[0]);
-            count_rms++;
-        }
+
         if (ssat[sat - 1].resp[0] != 0) {
             sum_rms = SQR(ssat[sat - 1].resp[0]);
             count_rms++;
         }
     }
     range_rms = SQRT(sum_rms) / count_rms;
-    p += sprintf(p, "$GPGST,%02.0f%02.0f%05.2f,%5.3f,,,,%5.3f,%5.3f,%5.3f",
-                 +ep[3], ep[4], ep[5], range_rms, SQRT(Q[0]), SQRT(Q[4]), SQRT(Q[8]));
+    p += sprintf(p, "$GNGST,%02.0f%02.0f%05.2f,%5.3f,,,,%5.3f,%5.3f,%5.3f",
+                 ep[3], ep[4], ep[5], range_rms, SQRT(Q[0]), SQRT(Q[4]), SQRT(Q[8]));
 
     for (q = (char *) buff + 1, sum = 0; *q; q++) sum ^= *q; /* check-sum */
     p += sprintf(p, "*%02X%c%c", sum, 0x0D, 0x0A);


### PR DESCRIPTION
 - RMC,GGA,VTG,GST: change Talker ID from GP(only GPS) to GN(multiple systems)
- GGA: use correct horizontal DOP
- GSV: refactor unobvious separation into messages
- GST: calculate RMS only for pseudorange residuals
- RMC,VTG: change speed calculations(from 3D to 2D), remove magnetic heading and
change direction calculations - don't hold and send wrong direction if speed is close to 0
- save kinematic speed in sol_t
