### PR TITLE
Multi-Hypothesis Kalman Filter Implementation

### DIFF
--- a/app/rnx2rtkp/gcc/makefile
+++ b/app/rnx2rtkp/gcc/makefile
@@ -8,7 +8,8 @@ BINDIR      = /usr/local/bin
 SRC_DIR_APP = ..
 SRC_DIR_1   = ../../../src
 SRC_DIR_2   = ../../../src/rcv
-SRC_DIRS   := $(SRC_DIR_APP) $(SRC_DIR_1) $(SRC_DIR_2)
+SRC_DIR_3   = ../../../src/MULTIHYPOTHESIS
+SRC_DIRS   := $(SRC_DIR_APP) $(SRC_DIR_1) $(SRC_DIR_2) $(SRC_DIR_3)
 
 vpath %.c $(SRC_DIRS)
 
@@ -19,15 +20,17 @@ SRC_NAMES_1   = stream.c rtkcmn.c rinex.c sbas.c preceph.c rcvraw.c convrnx.c \
     postpos.c rtkpos.c erb.c solution.c
 SRC_NAMES_2   = novatel.c ss2.c ublox.c crescent.c skytraq.c gw10.c javad.c nvs.c \
     binex.c rt17.c tersus.c septentrio.c cmr.c
-SRC_NAMES    := $(SRC_NAMES_APP) $(SRC_NAMES_1) $(SRC_NAMES_2) 
+SRC_NAMES_3   = multihypothesis.c fix_and_hold_refinement_strategy.c
+SRC_NAMES    := $(SRC_NAMES_APP) $(SRC_NAMES_1) $(SRC_NAMES_2) $(SRC_NAMES_3)
 
 # object files
 OBJ_NAMES    := $(SRC_NAMES:%.c=%.o)
 
 # common compile options
-INCLUDE := -I$(SRC_DIR_1)
+INCLUDE := -I$(SRC_DIR_1) -I$(SRC_DIR_3)
 OPTIONS := -DTRACE -DENAGLO -DENAQZS -DENAGAL -DENACMP -DENAIRN -DNFREQ=3 -DIERS_MODEL
-CFLAGS_CMN := -ansi -pedantic -Wall -Wno-unused-but-set-variable -fno-strict-overflow -Werror -Wno-error=unused-function $(INCLUDE) $(OPTIONS) -g
+CFLAGS_CMN := -ansi -pedantic -Wall -Wno-unused-but-set-variable -fno-strict-overflow \
+    -Werror -Wno-error=unused-function -Wno-error=unused-variable $(INCLUDE) $(OPTIONS) -g
 LDLIBS  := ../../../lib/iers/gcc/iers.a -lgfortran -lm -lrt -lpthread
 EXEC    := rnx2rtkp
 
@@ -73,21 +76,21 @@ debug: $(DBG_EXEC)
 $(REL_EXEC): $(addprefix $(REL_DIR)/,$(OBJ_NAMES))
 	$(CC) $^ -o $@ $(LDLIBS)
 
-$(REL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h
+$(REL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_3)/multihypothesis.h $(SRC_DIR_3)/fix_and_hold_refinement_strategy.h
 	$(CC) -c $(CFLAGS) $< -o $@
 
 #prerelease
 $(PREREL_EXEC): $(addprefix $(PREREL_DIR)/,$(OBJ_NAMES))
 	$(CC) $^ -o $@ $(LDLIBS)
 
-$(PREREL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h
+$(PREREL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_3)/multihypothesis.h $(SRC_DIR_3)/fix_and_hold_refinement_strategy.h
 	$(CC) -c $(CFLAGS) $< -o $@
 
 # debug
 $(DBG_EXEC): $(addprefix $(DBG_DIR)/,$(OBJ_NAMES))
 	$(CC) $^ -o $@ $(LDLIBS) 
 
-$(DBG_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h
+$(DBG_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_3)/multihypothesis.h $(SRC_DIR_3)/fix_and_hold_refinement_strategy.h
 	$(CC) -c $(CFLAGS) $< -o $@
 
 ####################################################################

--- a/app/rtkrcv/gcc/makefile
+++ b/app/rtkrcv/gcc/makefile
@@ -8,7 +8,8 @@ BINDIR      = /usr/local/bin
 SRC_DIR_APP = ..
 SRC_DIR_1   = ../../../src
 SRC_DIR_2   = ../../../src/rcv
-SRC_DIRS   := $(SRC_DIR_APP) $(SRC_DIR_1) $(SRC_DIR_2)
+SRC_DIR_3   = ../../../src/MULTIHYPOTHESIS
+SRC_DIRS   := $(SRC_DIR_APP) $(SRC_DIR_1) $(SRC_DIR_2) $(SRC_DIR_3)
 
 vpath %.c $(SRC_DIRS)
 
@@ -19,15 +20,17 @@ SRC_NAMES_1   = stream.c rtkcmn.c rinex.c sbas.c preceph.c rcvraw.c \
     rtksvr.c rtkpos.c erb.c solution.c
 SRC_NAMES_2   = novatel.c ss2.c ublox.c crescent.c skytraq.c gw10.c javad.c nvs.c \
     binex.c rt17.c tersus.c septentrio.c cmr.c
-SRC_NAMES    := $(SRC_NAMES_APP) $(SRC_NAMES_1) $(SRC_NAMES_2) 
+SRC_NAMES_3   = multihypothesis.c fix_and_hold_refinement_strategy.c
+SRC_NAMES    := $(SRC_NAMES_APP) $(SRC_NAMES_1) $(SRC_NAMES_2) $(SRC_NAMES_3)
 
 # object files
 OBJ_NAMES    := $(SRC_NAMES:%.c=%.o)
 
 # common compile options
-INCLUDE := -I$(SRC_DIR_1) -I$(SRC_DIR_APP)
+INCLUDE := -I$(SRC_DIR_1) -I$(SRC_DIR_APP) -I$(SRC_DIR_3)
 OPTIONS := -DTRACE -DENAGLO -DENAQZS -DENAGAL -DENACMP -DENAIRN -DNFREQ=3 -DSVR_REUSEADDR
-CFLAGS_CMN := -ansi -pedantic -Wall -Wno-unused-but-set-variable -fno-strict-overflow -Werror -Wno-error=unused-function $(INCLUDE) $(OPTIONS) -g
+CFLAGS_CMN := -ansi -pedantic -Wall -Wno-unused-but-set-variable -fno-strict-overflow \
+    -Werror -Wno-error=unused-function -Wno-error=unused-variable $(INCLUDE) $(OPTIONS) -g
 LDLIBS  := -lm -lrt -lpthread
 EXEC    := rtkrcv
 
@@ -73,21 +76,21 @@ debug: $(DBG_EXEC)
 $(REL_EXEC): $(addprefix $(REL_DIR)/,$(OBJ_NAMES))
 	$(CC) $^ -o $@ $(LDLIBS)
 
-$(REL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_APP)/vt.h
+$(REL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_APP)/vt.h $(SRC_DIR_3)/multihypothesis.h $(SRC_DIR_3)/fix_and_hold_refinement_strategy.h
 	$(CC) -c $(CFLAGS) $< -o $@
 
 #prerelease
 $(PREREL_EXEC): $(addprefix $(PREREL_DIR)/,$(OBJ_NAMES))
 	$(CC) $^ -o $@ $(LDLIBS)
 
-$(PREREL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_APP)/vt.h
+$(PREREL_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_APP)/vt.h $(SRC_DIR_3)/multihypothesis.h $(SRC_DIR_3)/fix_and_hold_refinement_strategy.h
 	$(CC) -c $(CFLAGS) $< -o $@
 
 # debug
 $(DBG_EXEC): $(addprefix $(DBG_DIR)/,$(OBJ_NAMES))
 	$(CC) $^ -o $@ $(LDLIBS) 
 
-$(DBG_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_APP)/vt.h
+$(DBG_DIR)/%.o: %.c $(SRC_DIR_1)/rtklib.h $(SRC_DIR_APP)/vt.h $(SRC_DIR_3)/multihypothesis.h $(SRC_DIR_3)/fix_and_hold_refinement_strategy.h
 	$(CC) -c $(CFLAGS) $< -o $@
 
 ####################################################################

--- a/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.c
+++ b/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.c
@@ -1,0 +1,239 @@
+/* 
+ *   FIX-AND-HOLD refinement strategy (FXHR)
+ */
+
+#include "fix_and_hold_refinement_strategy.h"
+
+extern rtk_multi_t *rtk_multi_init_fxhr(prcopt_t opt)
+{
+    rtk_multi_t   *rtk_multi = rtk_multi_init(opt);
+    rtk_history_t *hypothesis;
+    rtk_t         *rtk;
+
+    /* init float filter */
+    opt.modear = 0;
+    opt.gpsmodear = 0;
+    opt.glomodear = 0;
+    opt.bdsmodear = 0;
+    hypothesis = rtk_history_init(opt);
+    rtk = rtk_init(&opt);
+    rtk_history_add(hypothesis, rtk);
+    hypothesis->target_solution_status = SOLQ_FLOAT;
+    rtk_multi_add(rtk_multi, hypothesis);
+    
+    rtk_free(rtk);
+
+    return rtk_multi;
+}
+
+extern int rtk_multi_is_valid_fxhr(const rtk_multi_t *rtk_multi)
+{
+    int i;
+    
+    if ( !rtk_multi_is_valid(rtk_multi) ) {
+
+        return 0;
+    }
+    if ( rtk_multi->n_hypotheses > N_HYPOTHESES_FXHR ) {
+        
+        return 0;
+    }
+    /* float filter (hypothesis) should be defined */
+    if ( !rtk_history_is_valid(rtk_multi->hypotheses[0]) )  {
+
+        return 0;
+    }
+    if ( rtk_multi->hypotheses[0]->target_solution_status != SOLQ_FLOAT ) {
+
+        return 0;
+    }
+    for (i = 1; i < N_HYPOTHESES_FXHR; i++) {
+
+        if ( rtk_multi->hypotheses[i] == NULL ) continue;
+        if ( rtk_multi->hypotheses[i]->target_solution_status != SOLQ_FIX ) {
+
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/* return: -1 : validation impossible, 0 : not valid, 1 : valid */
+static int rtk_history_validate_fxhr(rtk_history_t *rtk_history)
+{
+    int i, sat, freq, n_epochs;
+    int n_fix_epochs = 0;
+    int n_fix_obs    = 0;
+    double sqr_residuals_fix = 0.0;
+    double rms_residuals_fix = 0.0;
+    double fix_fraction;
+    rtk_t *rtk;
+
+    assert( rtk_history_is_valid(rtk_history) );
+    n_epochs = rtk_history->history->length;
+    assert( n_epochs > 0 );
+    
+    rtk_history->solution_quality = -1.0;
+
+    if ( rtk_history->target_solution_status != SOLQ_FIX ) { /* validate only 'fix' hypotheses */
+        
+        return -1;
+    }
+    if ( n_epochs >= 2 ) {
+
+        for (i = 0; i < (n_epochs-1); i++) {
+            
+            rtk = rtk_history_get_pointer(rtk_history, i);
+            if ( rtk->sol.stat != SOLQ_FIX ) continue;
+            n_fix_epochs++;
+        }
+        fix_fraction = ((double) n_fix_epochs) / (n_epochs - 1);
+        if ( fix_fraction < MIN_FIX_FRACTION_FXHR ) {
+
+            rtk_history->solution_quality = LOW_SOL_QUAL + 1.0;
+            return -1;
+        }
+    }
+    if ( n_epochs < MIN_EPOCHS_FXHR ) {
+
+        return -1;
+    }
+
+    for (i = 0; i < n_epochs; i++) {
+        
+        rtk = rtk_history_get_pointer(rtk_history, i);
+        if ( rtk->sol.stat != SOLQ_FIX ) continue;
+
+        for (sat = 0; sat < MAXSAT; sat++) {
+            for (freq = 0; freq < rtk->opt.nf; freq++) {
+                
+                if ( rtk->ssat[sat].vsat[freq] == 0 ) continue;
+                if ( (rtk->ssat[sat].fix[freq] != 2)
+                  && (rtk->ssat[sat].fix[freq] != 3) ) continue;
+                if ( rtk->ssat[sat].resc[freq] == 0.0 
+                  && rtk->ssat[sat].resp[freq] == 0.0 ) continue;
+                
+                sqr_residuals_fix += SQR(rtk->ssat[sat].resc[freq]);
+                n_fix_obs++;
+            }
+        }
+    }
+      
+    if ( n_fix_obs > 0 ) rms_residuals_fix = sqrt(sqr_residuals_fix / n_fix_obs);
+
+    rtk_history->solution_quality = rms_residuals_fix;
+    
+    return (rms_residuals_fix < RESID_THRESH_FXHR);
+}
+
+extern void rtk_multi_split_fxhr(rtk_multi_t *rtk_multi, const rtk_input_data_t *rtk_input_data)
+{
+    static int split_outage = -1;
+    rtk_history_t *hypothesis;
+    int is_fix_possible = 0; 
+    int is_fix_hypothesis_of_low_quality = 0;
+    rtk_t *rtk;
+    rtk_t *rtk_tmp;
+    
+    assert( rtk_multi_is_valid_fxhr(rtk_multi) );
+    assert( rtk_input_data_is_valid(rtk_input_data) );
+
+    split_outage++;
+    if ( split_outage < SPLIT_INTERVAL_FXHR ) {
+
+        return;
+    }
+
+    /* check is there a place for a new hypothesis */
+    if ( rtk_multi->n_hypotheses >= N_HYPOTHESES_FXHR ) {
+
+        /* check if 'fix' hypothesis is weak or not */
+        hypothesis = rtk_multi->hypotheses[N_HYPOTHESES_FXHR-1];
+        rtk = rtk_history_get_pointer_to_last(hypothesis);
+        is_fix_hypothesis_of_low_quality = (rtk->sol.stat != SOLQ_FIX) 
+                                        && (hypothesis->solution_quality >= LOW_SOL_QUAL);
+        if ( !is_fix_hypothesis_of_low_quality ) {
+            
+            return;
+        }
+    }
+    
+    split_outage = 0;
+
+    /* check if fix is possible */
+    rtk = rtk_history_get_pointer_to_last(rtk_multi->hypotheses[0]);
+    rtk_tmp = rtk_init(&rtk_multi->opt);
+    rtk_copy(rtk, rtk_tmp);
+    rtk_tmp->opt = rtk_multi->opt;
+    rtkpos(rtk_tmp, rtk_input_data->obsd, rtk_input_data->n_obsd, rtk_input_data->nav);
+    is_fix_possible = (rtk_tmp->sol.stat == SOLQ_FIX);
+
+    if ( !is_fix_possible ) {
+
+        rtk_free(rtk_tmp);
+        return;
+    }
+
+    /* initialize new hypothesis structure */
+    rtk = rtk_history_get_pointer_to_last(rtk_multi->hypotheses[0]);
+    rtk_copy(rtk, rtk_tmp);
+    rtk_tmp->opt = rtk_multi->opt;
+    hypothesis = rtk_history_init(rtk_multi->opt);
+    hypothesis->target_solution_status = SOLQ_FIX;
+    rtk_history_add(hypothesis, rtk_tmp);
+
+    /* add new hypothesis if all checks are passed */
+    if ( is_fix_hypothesis_of_low_quality ) rtk_multi_exclude(rtk_multi, N_HYPOTHESES_FXHR-1); /* kill weak hypothesis */
+    rtk_multi_add(rtk_multi, hypothesis);
+
+    rtk_free(rtk_tmp);
+}
+
+extern void rtk_multi_qualify_fxhr(rtk_multi_t *rtk_multi)
+{
+    int i;
+    rtk_history_t *hypothesis;
+
+    assert( rtk_multi_is_valid_fxhr(rtk_multi) );
+    
+    /* exclude bad hypotheses */
+    for (i = 1; i < N_HYPOTHESES_FXHR; i++) { /* note: i == 0 is for float filter (never excluded) */
+        
+        hypothesis = rtk_multi->hypotheses[i];
+        if ( hypothesis == NULL ) continue;
+
+        if ( rtk_history_validate_fxhr(hypothesis) == 0 ) {
+            
+            rtk_multi_exclude(rtk_multi, i);
+        }
+    }
+    
+}
+
+extern void rtk_multi_merge_fxhr(rtk_multi_t *rtk_multi)
+{
+    rtk_history_t *hypothesis = NULL;
+    rtk_t *rtk;
+
+    assert( rtk_multi_is_valid_fxhr(rtk_multi) );
+
+    if ( rtk_multi->n_hypotheses == 1 ) { /* output float */
+
+        hypothesis = rtk_multi->hypotheses[0];
+        rtk = rtk_history_get_pointer_to_last(hypothesis);
+        rtk_copy(rtk, rtk_multi->rtk_out);
+    }
+
+    if ( rtk_multi->n_hypotheses > 1 ) { /* output fix */
+        
+        hypothesis = rtk_multi->hypotheses[1];
+        
+    }
+    
+    assert( rtk_history_is_valid(hypothesis) );
+    
+    rtk = rtk_history_get_pointer_to_last(hypothesis);
+    rtk_copy(rtk, rtk_multi->rtk_out);
+
+}

--- a/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.c
+++ b/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.c
@@ -61,16 +61,125 @@ extern int rtk_multi_is_valid_fxhr(const rtk_multi_t *rtk_multi)
     return 1;
 }
 
+static int are_solutions_close(const sol_t *sol_1, const sol_t *sol_2)
+{
+    double pos_1[3];
+    double pos_2[3];
+    double delta;
+
+    assert(sol_1 != NULL);
+    assert(sol_2 != NULL);
+
+    memcpy(pos_1, sol_1->rr, sizeof(double) * 3);
+    memcpy(pos_2, sol_2->rr, sizeof(double) * 3);
+
+    delta = sqrt(SQR(pos_2[0]-pos_1[0]) + SQR(pos_2[1]-pos_1[1]) + SQR(pos_2[2]-pos_1[2]));
+    if ( delta < RTK_POS_THRESH_FXHR ) {
+
+        return 1;
+    };
+
+    return 0;
+}
+
+static double get_fix_fraction(rtk_history_t *rtk_history)
+{
+    int i, n_epochs;
+    int n_fix_epochs = 0;
+    double fix_fraction;
+    rtk_t *rtk;
+
+    n_epochs = rtk_history->history->length;
+    
+    if ( n_epochs < 2 ) return 1.0; 
+
+    /* last epoch is allowed to be float and is not accounted */
+    for (i = 0; i < (n_epochs-1); i++) {
+            
+        rtk = rtk_history_get_pointer(rtk_history, i);
+        if ( rtk->sol.stat != SOLQ_FIX ) continue;
+        n_fix_epochs++;
+    }
+    fix_fraction = ((double) n_fix_epochs) / (n_epochs - 1);
+
+    return fix_fraction;
+}
+
+static int get_number_of_alternative_fixes(rtk_history_t *rtk_history)
+{
+    int i, n_epochs;
+    int n_alternative_fixes = 0;
+    rtk_t *rtk;
+
+    n_epochs = rtk_history->history->length;
+
+    for (i = 0; i < n_epochs; i++) {
+        
+        rtk = rtk_history_get_pointer(rtk_history, i);
+        if ( rtk->sol.stat != SOLQ_FIX ) {
+            
+            if ( rtk->is_alternative_fix_possible ) n_alternative_fixes++;
+            continue;
+        }
+
+        if ( rtk->is_alternative_fix_possible ) {
+            
+            if ( are_solutions_close(&rtk->sol, &rtk->sol_alternative) ) {
+                
+               rtk->is_alternative_fix_possible = 0;
+            }
+            else {
+                
+                n_alternative_fixes++;
+            }
+        }
+    }
+
+    return n_alternative_fixes;
+}
+
+static double get_rms_residuals_fix(rtk_history_t *rtk_history)
+{
+    int i, sat, freq, n_epochs;
+    int n_fix_obs = 0;
+    double sqr_residuals_fix = 0.0;
+    double rms_residuals_fix = 0.0;
+    rtk_t *rtk;
+
+    n_epochs = rtk_history->history->length;
+    
+    for (i = 0; i < n_epochs; i++) {
+        
+        rtk = rtk_history_get_pointer(rtk_history, i);
+        if ( rtk->sol.stat != SOLQ_FIX ) continue;
+        
+        for (sat = 0; sat < MAXSAT; sat++) {
+            for (freq = 0; freq < rtk->opt.nf; freq++) {
+                
+                if ( rtk->ssat[sat].vsat[freq] == 0 ) continue;   /* satellite is not valid */
+                if ( (rtk->ssat[sat].fix[freq] != 2)
+                  && (rtk->ssat[sat].fix[freq] != 3) ) continue;  /* satellite is not used for fix */
+                if ( rtk->ssat[sat].resc[freq] == 0.0 
+                  && rtk->ssat[sat].resp[freq] == 0.0 ) continue; /* residuals are not defined */
+                
+                sqr_residuals_fix += SQR(rtk->ssat[sat].resc[freq]);
+                n_fix_obs++;
+            }
+        }
+    }
+    
+    if ( n_fix_obs > 0 ) rms_residuals_fix = sqrt(sqr_residuals_fix / n_fix_obs);
+
+    return rms_residuals_fix;
+}
+
 /* return: -1 : validation impossible, 0 : not valid, 1 : valid */
 static int rtk_history_validate_fxhr(rtk_history_t *rtk_history)
 {
-    int i, sat, freq, n_epochs;
-    int n_fix_epochs = 0;
-    int n_fix_obs    = 0;
-    double sqr_residuals_fix = 0.0;
-    double rms_residuals_fix = 0.0;
+    int n_epochs;
+    int n_alternative_fixes;
+    double rms_residuals_fix;
     double fix_fraction;
-    rtk_t *rtk;
 
     assert( rtk_history_is_valid(rtk_history) );
     assert( !rtk_history_is_empty(rtk_history) );
@@ -85,13 +194,7 @@ static int rtk_history_validate_fxhr(rtk_history_t *rtk_history)
     }
     if ( n_epochs >= 2 ) {
 
-        for (i = 0; i < (n_epochs-1); i++) {
-            
-            rtk = rtk_history_get_pointer(rtk_history, i);
-            if ( rtk->sol.stat != SOLQ_FIX ) continue;
-            n_fix_epochs++;
-        }
-        fix_fraction = ((double) n_fix_epochs) / (n_epochs - 1);
+        fix_fraction = get_fix_fraction(rtk_history);
         if ( fix_fraction < MIN_FIX_FRACTION_FXHR ) {
 
             rtk_history->solution_quality = LOW_SOL_QUAL + 1.0;
@@ -103,38 +206,21 @@ static int rtk_history_validate_fxhr(rtk_history_t *rtk_history)
         return -1;
     }
 
-    for (i = 0; i < n_epochs; i++) {
-        
-        rtk = rtk_history_get_pointer(rtk_history, i);
-        if ( rtk->sol.stat != SOLQ_FIX ) continue;
-
-        for (sat = 0; sat < MAXSAT; sat++) {
-            for (freq = 0; freq < rtk->opt.nf; freq++) {
-                
-                if ( rtk->ssat[sat].vsat[freq] == 0 ) continue;
-                if ( (rtk->ssat[sat].fix[freq] != 2)
-                  && (rtk->ssat[sat].fix[freq] != 3) ) continue;
-                if ( rtk->ssat[sat].resc[freq] == 0.0 
-                  && rtk->ssat[sat].resp[freq] == 0.0 ) continue;
-                
-                sqr_residuals_fix += SQR(rtk->ssat[sat].resc[freq]);
-                n_fix_obs++;
-            }
-        }
-    }
-      
-    if ( n_fix_obs > 0 ) rms_residuals_fix = sqrt(sqr_residuals_fix / n_fix_obs);
+    n_alternative_fixes = get_number_of_alternative_fixes(rtk_history);
+    rms_residuals_fix   = get_rms_residuals_fix(rtk_history);
 
     rtk_history->solution_quality = rms_residuals_fix;
     
-    return (rms_residuals_fix < RESID_THRESH_FXHR);
+    return (rms_residuals_fix < RESID_THRESH_FXHR) 
+        && ((n_alternative_fixes < MIN_ALTERNATIVE_FIXES_FXHR) 
+            || (rms_residuals_fix < RESID_FINE_TRESH_FXHR));
 }
 
 extern void rtk_multi_split_fxhr(rtk_multi_t *rtk_multi, const rtk_input_data_t *rtk_input_data)
 {
     static int split_outage = -1;
     rtk_history_t *hypothesis;
-    int i, index_new;
+    int index_new;
     int is_fix_possible = 0; 
     int is_fix_hypothesis_of_low_quality = 0;
     rtk_t *rtk;
@@ -142,17 +228,6 @@ extern void rtk_multi_split_fxhr(rtk_multi_t *rtk_multi, const rtk_input_data_t 
     
     assert( rtk_multi_is_valid_fxhr(rtk_multi) );
     assert( rtk_input_data_is_valid(rtk_input_data) );
-
-    /* renew the base position */
-    for (i = 0; i < N_HYPOTHESES_FXHR; i++ ) {
-        
-        hypothesis = rtk_multi->hypotheses[i];
-        if ( rtk_history_is_empty(hypothesis) ) continue;
-        
-        rtk = rtk_history_get_pointer_to_last(hypothesis);
-        memcpy(rtk->opt.rb, rtk_multi->opt.rb, sizeof(double) * 3);
-        memcpy(rtk->rb, rtk_multi->opt.rb, sizeof(double) * 3);
-    }
     
     split_outage++;
     if ( split_outage < SPLIT_INTERVAL_FXHR ) {
@@ -160,20 +235,6 @@ extern void rtk_multi_split_fxhr(rtk_multi_t *rtk_multi, const rtk_input_data_t 
         return;
     }
 
-    /* check is there a place for a new hypothesis */
-    if ( rtk_multi->n_hypotheses >= N_HYPOTHESES_FXHR ) {
-
-        /* check if 'fix' hypothesis is weak or not */
-        hypothesis = rtk_multi->hypotheses[N_HYPOTHESES_FXHR-1];
-        rtk = rtk_history_get_pointer_to_last(hypothesis);
-        is_fix_hypothesis_of_low_quality = (rtk->sol.stat != SOLQ_FIX) 
-                                        && (hypothesis->solution_quality >= LOW_SOL_QUAL);
-        if ( !is_fix_hypothesis_of_low_quality ) {
-            
-            return;
-        }
-    }
-    
     split_outage = 0;
 
     /* check if fix is possible */
@@ -184,6 +245,34 @@ extern void rtk_multi_split_fxhr(rtk_multi_t *rtk_multi, const rtk_input_data_t 
     rtkpos(rtk_tmp, rtk_input_data->obsd, rtk_input_data->n_obsd, rtk_input_data->nav);
     is_fix_possible = (rtk_tmp->sol.stat == SOLQ_FIX);
     ratio_float = rtk_tmp->sol.ratio;
+    
+    /* check is there a fix hypothesis */
+    if ( rtk_multi->n_hypotheses >= N_HYPOTHESES_FXHR ) {
+        
+        hypothesis = rtk_multi->hypotheses[N_HYPOTHESES_FXHR-1];
+        rtk = rtk_history_get_pointer_to_last(hypothesis);
+        
+        /* check if 'fix' hypothesis is weak or not */
+        is_fix_hypothesis_of_low_quality = (rtk->sol.stat != SOLQ_FIX) 
+                                        && (hypothesis->solution_quality >= LOW_SOL_QUAL);
+        
+        /* add alternative fix record */
+        if ( is_fix_possible ) {
+            
+            rtk->is_alternative_fix_possible = 1;
+            rtk->sol_alternative = rtk_tmp->sol;
+        }
+        else {
+            
+            rtk->is_alternative_fix_possible = 0;
+        }
+        
+        if ( !is_fix_hypothesis_of_low_quality ) {
+            
+            rtk_free(rtk_tmp);
+            return;
+        }
+    }
 
     if ( !is_fix_possible ) {
 
@@ -197,7 +286,10 @@ extern void rtk_multi_split_fxhr(rtk_multi_t *rtk_multi, const rtk_input_data_t 
     rtk_tmp->opt = rtk_multi->opt;
     
     /* add new hypothesis if all checks are passed */
-    if ( is_fix_hypothesis_of_low_quality ) rtk_multi_exclude(rtk_multi, N_HYPOTHESES_FXHR-1); /* kill weak hypothesis */
+    if ( is_fix_hypothesis_of_low_quality ) {
+
+        rtk_multi_exclude(rtk_multi, N_HYPOTHESES_FXHR-1); /* kill weak hypothesis */
+    }
     index_new = rtk_multi_add(rtk_multi, rtk_tmp);
     rtk_multi->hypotheses[index_new]->target_solution_status = SOLQ_FIX;
 

--- a/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.c
+++ b/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.c
@@ -228,7 +228,6 @@ extern void rtk_multi_merge_fxhr(rtk_multi_t *rtk_multi)
     if ( rtk_multi->n_hypotheses > 1 ) { /* output fix */
         
         hypothesis = rtk_multi->hypotheses[1];
-        
     }
     
     assert( rtk_history_is_valid(hypothesis) );

--- a/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.h
+++ b/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.h
@@ -1,0 +1,26 @@
+/* 
+ *   FIX-AND-HOLD refinement strategy (FXHR)
+ */
+
+#ifndef FIX_AND_HOLD_REFINEMENT_STRATEGY_H
+#define FIX_AND_HOLD_REFINEMENT_STRATEGY_H
+
+#include "rtklib.h"
+#include "multihypothesis.h"
+
+#define N_HYPOTHESES_FXHR     2      /* 'float' and 'fix' hypotheses */
+#define MIN_EPOCHS_FXHR       100    /* min number of epochs for hypothesis to validate */
+#define MIN_FIX_FRACTION_FXHR 0.70   /* min fix fraction for hypothesis to validate */
+#define RESID_THRESH_FXHR     0.02   /* max RMSE of phase residuals allowed for 'fix hypothesis' 
+                                        to been mark as valid [m] */
+#define SPLIT_INTERVAL_FXHR   10     /* time span between split operations (epochs) */
+#define LOW_SOL_QUAL          100.0  /* low solution quality threshold (rtk_history->solution_quality) */
+
+extern rtk_multi_t *rtk_multi_init_fxhr(prcopt_t opt);
+extern int rtk_multi_is_valid_fxhr(const rtk_multi_t *rtk_multi);
+
+extern void rtk_multi_split_fxhr(rtk_multi_t *rtk_multi, const rtk_input_data_t *rtk_input_data);
+extern void rtk_multi_qualify_fxhr(rtk_multi_t *rtk_multi);
+extern void rtk_multi_merge_fxhr(rtk_multi_t *rtk_multi);
+
+#endif /* #ifndef FIX_AND_HOLD_REFINEMENT_STRATEGY_H */

--- a/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.h
+++ b/src/MULTIHYPOTHESIS/fix_and_hold_refinement_strategy.h
@@ -16,6 +16,11 @@
 #define SPLIT_INTERVAL_FXHR   10     /* time span between split operations (epochs) */
 #define LOW_SOL_QUAL          100.0  /* low solution quality threshold (rtk_history->solution_quality) */
 
+#define RTK_POS_THRESH_FXHR        0.1    /* min 3D distance between solutions to distinguish */
+#define MIN_ALTERNATIVE_FIXES_FXHR 10     /* min number of alternative fixes (epochs) 
+                                             to discard fix hypothesis */
+#define RESID_FINE_TRESH_FXHR      0.01   /* don't discard fix if RMS of phase residuals is fine [m] */
+
 extern rtk_multi_t *rtk_multi_init_fxhr(prcopt_t opt);
 extern int rtk_multi_is_valid_fxhr(const rtk_multi_t *rtk_multi);
 

--- a/src/MULTIHYPOTHESIS/multihypothesis.c
+++ b/src/MULTIHYPOTHESIS/multihypothesis.c
@@ -1,0 +1,452 @@
+#include "multihypothesis.h"
+
+/* -------------------------------------------------------------------------- */
+/* manipulation functions --------------------------------------------------- */
+
+/* rtk_queue */
+
+static rtk_queue_t *rtk_queue_init(prcopt_t opt)
+{
+    int i, j;
+    rtk_queue_t *rtk_queue = malloc(sizeof(rtk_queue_t));
+    if ( rtk_queue == NULL ) {
+
+        return NULL;
+    }
+    
+    rtk_queue->length = 0;
+
+    for (i = 0; i < MAX_RTK_QUEUE; i++) {
+        
+        rtk_queue->offset[i] = i;
+        rtk_queue->rtk[i] = rtk_init(&opt);
+        if ( rtk_queue->rtk[i] == NULL ) {
+            for (j = 0; j < i; j++) rtk_free(rtk_queue->rtk[j]);
+            free(rtk_queue);
+            return NULL;
+        }
+    }
+    
+    return rtk_queue;
+}
+
+static int rtk_queue_is_valid(const rtk_queue_t *rtk_queue)
+{
+    int i;
+    int offsets_check[MAX_RTK_QUEUE] = {0};
+    
+    if ( rtk_queue == NULL ) {
+        
+        return 0;
+    }
+    if ( (rtk_queue->length < 0) || (rtk_queue->length > MAX_RTK_QUEUE) ) {
+        
+        return 0;
+    }
+
+    for (i = 0; i < MAX_RTK_QUEUE; i++) {   
+        
+        if ( !rtk_is_valid(rtk_queue->rtk[i]) ) {
+            
+            return 0;
+        }
+        if ( (rtk_queue->offset[i] < 0) || (rtk_queue->offset[i] >= MAX_RTK_QUEUE) ) {
+            
+            return 0;
+        }
+        offsets_check[rtk_queue->offset[i]] = 1;
+    }
+    
+    for (i = 0; i < MAX_RTK_QUEUE; i++) {
+        if ( offsets_check[i] == 0 ) {
+
+            return 0;
+        }
+    }
+    
+    return 1;
+}
+
+static void rtk_queue_free(rtk_queue_t *rtk_queue)
+{
+    int i;
+    assert( rtk_queue_is_valid(rtk_queue) );
+
+    for (i = 0; i < MAX_RTK_QUEUE; i++) {
+        if ( rtk_queue->rtk[i] != NULL ) rtk_free(rtk_queue->rtk[i]);
+    }
+    
+    free(rtk_queue);
+}
+
+static int rtk_queue_is_index_valid(const rtk_queue_t *rtk_queue, int index)
+{
+    int is_index_in_bounds;
+    assert( rtk_queue_is_valid(rtk_queue) );
+
+    is_index_in_bounds = (index >= 0) && (index < MAX_RTK_QUEUE) && (index < rtk_queue->length);
+    if ( !is_index_in_bounds ) {
+        
+        return 0;
+    }
+    
+    return 1;
+}
+
+static void rtk_queue_cut(rtk_queue_t *rtk_queue, int index_cut)
+{
+    int i;
+    int offset_cut[MAX_RTK_QUEUE];
+    
+    assert( rtk_queue_is_valid(rtk_queue) );
+    assert( rtk_queue_is_index_valid(rtk_queue, index_cut) );
+    
+    if ( index_cut > 0 ) {
+        for (i = 0; i < index_cut; i++ ) {
+            offset_cut[i] = rtk_queue->offset[i];
+        }
+        for (i = 0; i < MAX_RTK_QUEUE - index_cut; i++ ) {
+            rtk_queue->offset[i] = rtk_queue->offset[i + index_cut];
+        }
+        for (i = MAX_RTK_QUEUE - index_cut; i < MAX_RTK_QUEUE; i++ ) {
+            rtk_queue->offset[i] = offset_cut[i - MAX_RTK_QUEUE + index_cut];
+        }
+        rtk_queue->length -= index_cut;
+    }
+
+}
+
+static void rtk_queue_add(rtk_queue_t *rtk_queue, const rtk_t *rtk, int n_rtk)
+{
+    int i, offset;
+    
+    assert( rtk_queue_is_valid(rtk_queue) );
+    assert( n_rtk >= 0 );
+    
+    for (i = 0; i < n_rtk; i++) {
+
+        assert( rtk_is_valid(&rtk[i]) );
+
+        /* add i-th rtk to the queue */
+        if ( rtk_queue->length <= 0 ) {
+            offset = rtk_queue->offset[0];
+            rtk_queue->length = 1;
+        }
+        else if ( rtk_queue->length < MAX_RTK_QUEUE ) {
+            offset = rtk_queue->offset[rtk_queue->length];
+            rtk_queue->length++;
+        }
+        else { /* rtk_queue->length >= MAX_RTK_QUEUE */
+            rtk_queue_cut(rtk_queue, 1);
+            offset = rtk_queue->offset[MAX_RTK_QUEUE - 1];
+            rtk_queue->length = MAX_RTK_QUEUE;
+        }
+        rtk_copy(&rtk[i], rtk_queue->rtk[offset]);
+    }
+    
+}
+
+static rtk_t *rtk_queue_get_pointer(const rtk_queue_t *rtk_queue, int index_head)
+{
+    int offset, index_tail;
+
+    assert( rtk_queue_is_valid(rtk_queue) );
+    
+    index_tail = rtk_queue->length - 1 - index_head;
+    assert( (index_tail >= 0) && (index_tail < MAX_RTK_QUEUE) && "index is out of bounds" );
+    
+    if ( !rtk_queue_is_index_valid(rtk_queue, index_tail) ) {
+        
+        return NULL;
+    }
+
+    offset = rtk_queue->offset[index_tail];
+
+    return rtk_queue->rtk[offset];
+}
+
+/* rtk_history */
+
+extern rtk_history_t *rtk_history_init(prcopt_t opt)
+{
+    rtk_history_t *rtk_history = malloc(sizeof(rtk_history_t));
+    if ( rtk_history == NULL ) {
+
+        return NULL;
+    }
+
+    rtk_history->target_solution_status = SOLQ_NONE;
+    rtk_history->solution_quality = -1.0;
+    rtk_history->history = rtk_queue_init(opt);
+    if ( rtk_history->history == NULL ) {
+
+        free(rtk_history);
+        return NULL;
+    }
+
+    return rtk_history;
+}
+
+extern int rtk_history_is_valid(const rtk_history_t *rtk_history)
+{
+    int sol_stat;
+    
+    if ( rtk_history == NULL ) {
+
+        return 0;
+    }
+    sol_stat = rtk_history->target_solution_status;
+    if ( (sol_stat < 0) || (sol_stat > MAXSOLQ) ) {
+
+        return 0;
+    }
+    if ( !rtk_queue_is_valid(rtk_history->history) ) {
+
+        return 0;
+    }
+
+    return 1;
+}
+
+extern void rtk_history_free(rtk_history_t *rtk_history)
+{
+    assert(rtk_history_is_valid(rtk_history));
+
+    rtk_queue_free(rtk_history->history);
+    free(rtk_history);
+}
+
+extern void rtk_history_add(rtk_history_t *rtk_history, const rtk_t *rtk)
+{
+    assert( rtk_history_is_valid(rtk_history) );
+    assert( rtk_is_valid(rtk) );
+
+    rtk_queue_add(rtk_history->history, rtk, 1);
+}
+
+extern void rtk_history_cut(rtk_history_t *rtk_history, int index_cut)
+{
+    assert( rtk_history_is_valid(rtk_history) );
+
+    rtk_queue_cut(rtk_history->history, index_cut);
+}
+
+extern rtk_t *rtk_history_get_pointer(const rtk_history_t *rtk_history, int index)
+{
+    assert( rtk_history_is_valid(rtk_history) );
+
+    return rtk_queue_get_pointer(rtk_history->history, index);
+}
+
+extern rtk_t *rtk_history_get_pointer_to_last(const rtk_history_t *rtk_history)
+{
+    assert( rtk_history_is_valid(rtk_history) );
+
+    return rtk_queue_get_pointer(rtk_history->history, 0);
+}
+
+/* rtk_multi_strategy */
+
+extern int rtk_multi_strategy_is_valid(const rtk_multi_strategy_t *rtk_multi_strategy)
+{
+    if ( rtk_multi_strategy == NULL ) {
+
+        return 0;
+    }
+
+    if ( (rtk_multi_strategy->split == NULL)
+      || (rtk_multi_strategy->qualify == NULL)
+      || (rtk_multi_strategy->merge == NULL) ) {
+
+        return 0;
+    }
+
+    return 1;
+}
+
+/* rtk_input_data */
+
+extern int rtk_input_data_is_valid(const rtk_input_data_t *rtk_input_data)
+{
+    int n_obsd = rtk_input_data->n_obsd;
+    
+    if ( rtk_input_data == NULL ) {
+        
+        return 0;
+    }
+    if ( rtk_input_data->obsd == NULL ) {
+        
+        return 0;
+    }
+    if ( (n_obsd < 0) || (n_obsd > MAXOBS * 2) ) {
+        
+        return 0;
+    }
+    if ( rtk_input_data->nav == NULL ) {
+        
+        return 0;
+    }
+    
+    return 1;
+}
+
+/* rtk_multi */
+
+extern rtk_multi_t *rtk_multi_init(prcopt_t opt)
+{
+    int i;
+    rtk_multi_t *rtk_multi = malloc(sizeof(rtk_multi_t));
+    if ( rtk_multi == NULL ) {
+        
+        return NULL;
+    }
+    
+    rtk_multi->opt = opt;
+    rtk_multi->rtk_out = rtk_init(&opt);
+    if ( rtk_multi->rtk_out == NULL ) {
+
+        free(rtk_multi);
+        return NULL;
+    }
+
+    for (i = 0; i < MAX_RTK_HYPOTHESES; i++) {
+        
+        rtk_multi->hypotheses[i] = NULL;
+    }
+    rtk_multi->n_hypotheses = 0;
+    
+    return rtk_multi;
+}
+
+extern int rtk_multi_is_valid(const rtk_multi_t *rtk_multi)
+{
+    int i, is_n_hypotheses_in_bounds;
+    int n_hypotheses = 0;
+    
+    if ( rtk_multi == NULL ) {
+        
+        return 0;
+    }
+
+    is_n_hypotheses_in_bounds = (rtk_multi->n_hypotheses >= 0) 
+                             && (rtk_multi->n_hypotheses <= MAX_RTK_HYPOTHESES);
+
+    if ( !is_n_hypotheses_in_bounds ) {
+    
+        return 0;
+    }
+    if ( !rtk_is_valid(rtk_multi->rtk_out) ) {
+
+        return 0;
+    }
+
+    for (i = 0; i < MAX_RTK_HYPOTHESES; i++) {
+
+        if ( rtk_multi->hypotheses[i] == NULL ) continue;
+        if ( !rtk_history_is_valid(rtk_multi->hypotheses[i]) ) {
+
+            return 0;
+        }
+        n_hypotheses++;
+    }
+    if ( n_hypotheses != rtk_multi->n_hypotheses ) {
+
+        return 0;
+    }
+
+    return 1;
+}
+
+extern void rtk_multi_free(rtk_multi_t *rtk_multi)
+{
+    int i;
+
+    assert( rtk_multi_is_valid(rtk_multi) );
+    
+    for (i = 0; i < MAX_RTK_HYPOTHESES; i++) {
+
+        if ( rtk_multi->hypotheses[i] != NULL ) {
+            
+            rtk_history_free(rtk_multi->hypotheses[i]);
+        }
+    }
+
+    rtk_free(rtk_multi->rtk_out);
+    free(rtk_multi);
+}
+
+extern int rtk_multi_add(rtk_multi_t *rtk_multi, rtk_history_t *hypothesis)
+{
+    int i;
+    
+    assert( rtk_multi_is_valid(rtk_multi) );
+    assert( rtk_history_is_valid(hypothesis) );
+    
+    /* try to find a vacancy */
+    for (i = 0; i < MAX_RTK_HYPOTHESES; i++) {
+
+        if ( rtk_multi->hypotheses[i] == NULL ) break;
+    }
+
+    if ( i >= MAX_RTK_HYPOTHESES ) { /* no free space */
+
+        return 0;
+    }
+    
+    rtk_multi->hypotheses[i] = hypothesis;
+    rtk_multi->n_hypotheses++;
+
+    return 1;
+} 
+
+extern int rtk_multi_exclude(rtk_multi_t *rtk_multi, int index)
+{
+    int is_index_in_bounds = (index >= 0) && (index < MAX_RTK_HYPOTHESES);
+    
+    assert( rtk_multi_is_valid(rtk_multi) );
+    assert( is_index_in_bounds );
+
+    if ( rtk_multi->hypotheses[index] == NULL ) {
+
+        return 0;
+    }
+
+    rtk_history_free(rtk_multi->hypotheses[index]);
+    rtk_multi->hypotheses[index] = NULL;
+    rtk_multi->n_hypotheses--;
+
+    return 1;
+}
+
+extern void rtk_multi_estimate(rtk_multi_t *rtk_multi,
+                               const rtk_multi_strategy_t *rtk_multi_strategy, 
+                               const rtk_input_data_t *rtk_input_data)
+{
+    int i;
+    rtk_t *rtk;
+    rtk_t *rtk_last;
+    rtk_history_t *hypothesis;
+    
+    assert( rtk_multi_is_valid(rtk_multi) );
+    assert( rtk_multi_strategy_is_valid(rtk_multi_strategy) );
+    assert( rtk_input_data_is_valid(rtk_input_data) );
+
+    rtk_multi_strategy->split(rtk_multi, rtk_input_data);
+    
+    for (i = 0; i < MAX_RTK_HYPOTHESES; i++) {
+        
+        hypothesis = rtk_multi->hypotheses[i];
+        if ( hypothesis == NULL ) continue;
+
+        rtk_last = rtk_history_get_pointer_to_last(hypothesis);
+        rtk = rtk_init(&rtk_last->opt);
+        rtk_copy(rtk_last, rtk);
+        rtkpos(rtk, rtk_input_data->obsd, rtk_input_data->n_obsd, rtk_input_data->nav);
+        rtk_history_add(hypothesis, rtk);
+        rtk_free(rtk);
+    }
+    
+    rtk_multi_strategy->qualify(rtk_multi);
+    
+    rtk_multi_strategy->merge(rtk_multi);
+}

--- a/src/MULTIHYPOTHESIS/multihypothesis.c
+++ b/src/MULTIHYPOTHESIS/multihypothesis.c
@@ -486,7 +486,7 @@ extern void rtk_multi_estimate(rtk_multi_t *rtk_multi,
     int i;
     rtk_history_t *hypothesis;
     rtk_multi_single_iteration_args_t args[MAX_RTK_HYPOTHESES];
-    pthread_t threads[MAX_RTK_HYPOTHESES];
+    thread_t threads[MAX_RTK_HYPOTHESES];
     
     assert( rtk_multi_is_valid(rtk_multi) );
     assert( rtk_multi_strategy_is_valid(rtk_multi_strategy) );

--- a/src/MULTIHYPOTHESIS/multihypothesis.h
+++ b/src/MULTIHYPOTHESIS/multihypothesis.h
@@ -67,6 +67,8 @@ extern void rtk_history_free(rtk_history_t *rtk_history);
 
 extern void rtk_history_cut(rtk_history_t *rtk_history, int index_cut);
 extern void rtk_history_add(rtk_history_t *rtk_history, const rtk_t *rtk);
+extern int  rtk_history_is_empty(const rtk_history_t *rtk_history);
+extern void rtk_history_clear(rtk_history_t *rtk_history);
 extern rtk_t *rtk_history_get_pointer(const rtk_history_t *rtk_history, int index);
 extern rtk_t *rtk_history_get_pointer_to_last(const rtk_history_t *rtk_history);
 
@@ -80,7 +82,7 @@ extern rtk_multi_t *rtk_multi_init(prcopt_t opt);
 extern int rtk_multi_is_valid(const rtk_multi_t *rtk_multi);
 extern void rtk_multi_free(rtk_multi_t *rtk_multi);
 
-extern int rtk_multi_add(rtk_multi_t *rtk_multi, rtk_history_t *hypothesis);
+extern int rtk_multi_add(rtk_multi_t *rtk_multi, rtk_t *rtk);
 extern int rtk_multi_exclude(rtk_multi_t *rtk_multi, int index);
 
 extern void rtk_multi_estimate(rtk_multi_t *rtk_multi,

--- a/src/MULTIHYPOTHESIS/multihypothesis.h
+++ b/src/MULTIHYPOTHESIS/multihypothesis.h
@@ -3,8 +3,8 @@
 
 #include "rtklib.h"
 
-#define MAX_RTK_HYPOTHESES 10        /* max number of hypotheses */
-#define MAX_RTK_QUEUE      300       /* max number of epochs stored */
+#define MAX_RTK_HYPOTHESES 5         /* max number of hypotheses */
+#define MAX_RTK_QUEUE      150       /* max number of epochs stored */
 
 #define SQR(x) ((x) * (x))
 
@@ -38,9 +38,9 @@ typedef struct {
 
 typedef struct {
 
-    obsd_t *obsd;
-    int     n_obsd;
-    nav_t  *nav;
+    obsd_t *obsd;                   /* observation data */
+    int     n_obsd;                 /* number of data records */
+    nav_t  *nav;                    /* navigation data */
 
 } rtk_input_data_t;
 
@@ -65,8 +65,8 @@ extern rtk_history_t *rtk_history_init(prcopt_t opt);
 extern int rtk_history_is_valid(const rtk_history_t *rtk_history);
 extern void rtk_history_free(rtk_history_t *rtk_history);
 
-extern void rtk_history_cut(rtk_history_t *rtk_history, int index_cut);
 extern void rtk_history_add(rtk_history_t *rtk_history, const rtk_t *rtk);
+extern void rtk_history_cut(rtk_history_t *rtk_history, int n_cut);
 extern int  rtk_history_is_empty(const rtk_history_t *rtk_history);
 extern void rtk_history_clear(rtk_history_t *rtk_history);
 extern rtk_t *rtk_history_get_pointer(const rtk_history_t *rtk_history, int index);
@@ -83,7 +83,7 @@ extern int rtk_multi_is_valid(const rtk_multi_t *rtk_multi);
 extern void rtk_multi_free(rtk_multi_t *rtk_multi);
 
 extern int rtk_multi_add(rtk_multi_t *rtk_multi, rtk_t *rtk);
-extern int rtk_multi_exclude(rtk_multi_t *rtk_multi, int index);
+extern void rtk_multi_exclude(rtk_multi_t *rtk_multi, int index);
 
 extern void rtk_multi_estimate(rtk_multi_t *rtk_multi,
                                const rtk_multi_strategy_t *rtk_multi_strategy, 

--- a/src/MULTIHYPOTHESIS/multihypothesis.h
+++ b/src/MULTIHYPOTHESIS/multihypothesis.h
@@ -1,0 +1,94 @@
+#ifndef MULTIHYPOTHESIS_H
+#define MULTIHYPOTHESIS_H
+
+#include "rtklib.h"
+
+#define MAX_RTK_HYPOTHESES 10        /* max number of hypotheses */
+#define MAX_RTK_QUEUE      300       /* max number of epochs stored */
+
+#define SQR(x) ((x) * (x))
+
+/* ------------------------------------------------------------------------- */
+/* basic types ------------------------------------------------------------- */
+
+typedef struct {
+
+    int    length;                 /* in [0, MAX_RTK_QUEUE] */
+    int    offset[MAX_RTK_QUEUE];  /* i-th element in the queue is stored in rtk[offset[i]] */
+    rtk_t *rtk[MAX_RTK_QUEUE];     /* rtk structures (queue nodes) */
+
+} rtk_queue_t;
+
+typedef struct {
+
+    int    target_solution_status; /* SOLQ_FIX, SOLQ_FLOAT, SOLQ_... */
+    double solution_quality;       /* 0.0 is the best, negative value means 'is not defined' */
+    rtk_queue_t *history;          /* rtk state for several consequtive epochs */
+    
+} rtk_history_t;
+
+typedef struct {
+    
+    int      n_hypotheses;         /* number of active hypotheses */
+    rtk_history_t *hypotheses[MAX_RTK_HYPOTHESES];
+    rtk_t   *rtk_out;              /* resulting rtk solution structure to output */
+    prcopt_t opt;                  /* processing options */
+    
+} rtk_multi_t;
+
+typedef struct {
+
+    obsd_t *obsd;
+    int     n_obsd;
+    nav_t  *nav;
+
+} rtk_input_data_t;
+
+typedef void (*rtk_multi_split_fpt)   (rtk_multi_t *, const rtk_input_data_t *);
+typedef void (*rtk_multi_qualify_fpt) (rtk_multi_t *);
+typedef void (*rtk_multi_merge_fpt)   (rtk_multi_t *);
+
+typedef struct {
+    
+    rtk_multi_split_fpt   split;
+    rtk_multi_qualify_fpt qualify;
+    rtk_multi_merge_fpt   merge;
+    
+} rtk_multi_strategy_t;
+
+/* -------------------------------------------------------------------------- */
+/* manipulation functions --------------------------------------------------- */
+
+/* rtk_history */
+
+extern rtk_history_t *rtk_history_init(prcopt_t opt);
+extern int rtk_history_is_valid(const rtk_history_t *rtk_history);
+extern void rtk_history_free(rtk_history_t *rtk_history);
+
+extern void rtk_history_cut(rtk_history_t *rtk_history, int index_cut);
+extern void rtk_history_add(rtk_history_t *rtk_history, const rtk_t *rtk);
+extern rtk_t *rtk_history_get_pointer(const rtk_history_t *rtk_history, int index);
+extern rtk_t *rtk_history_get_pointer_to_last(const rtk_history_t *rtk_history);
+
+/* rtk_input_data */
+
+extern int rtk_input_data_is_valid(const rtk_input_data_t *rtk_input_data);
+
+/* rtk_multi */
+
+extern rtk_multi_t *rtk_multi_init(prcopt_t opt);
+extern int rtk_multi_is_valid(const rtk_multi_t *rtk_multi);
+extern void rtk_multi_free(rtk_multi_t *rtk_multi);
+
+extern int rtk_multi_add(rtk_multi_t *rtk_multi, rtk_history_t *hypothesis);
+extern int rtk_multi_exclude(rtk_multi_t *rtk_multi, int index);
+
+extern void rtk_multi_estimate(rtk_multi_t *rtk_multi,
+                               const rtk_multi_strategy_t *rtk_multi_strategy, 
+                               const rtk_input_data_t *rtk_input_data);
+
+/* rtk_multi_strategy */
+
+extern int rtk_multi_strategy_is_valid(const rtk_multi_strategy_t *rtk_multi_strategy);
+
+#endif /* #ifndef MULTIHYPOTHESIS_H */

--- a/src/options.c
+++ b/src/options.c
@@ -127,6 +127,8 @@ EXPORT opt_t sysopts[]={
     {"resid-reset_float",1, (void *)&prcopt_.residual_reset_float,"m"},
     {"resid-block_fix_sat",1,(void *)&prcopt_.residual_block_fix_sat, "m"},
     
+    {"multihyp-mode",   3,  (void *)&prcopt_.multihyp_mode,SWTOPT},
+    
     {"out-solformat",   3,  (void *)&solopt_.posf,       SOLOPT },
     {"out-outhead",     3,  (void *)&solopt_.outhead,    SWTOPT },
     {"out-outopt",      3,  (void *)&solopt_.outopt,     SWTOPT },

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -459,7 +459,7 @@ static void procpos(FILE *fp, FILE *fptm, const prcopt_t *popt, const solopt_t *
             for (i=0;i<n;i++) obs[i].L[1]=obs[i].P[1]=0.0;
         }
 #endif
-        if ( (popt->multihyp_mode) && (popt->modear == 3) ) { /* multihypothesis mode on */
+        if ( (popt->multihyp_mode) && (popt->modear == ARMODE_FIXHOLD) ) { /* multihypothesis mode on */
             
             rtk_input_data->obsd = obs;
             rtk_input_data->n_obsd = n;
@@ -1181,13 +1181,13 @@ static int execses(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
 
     iobsu=iobsr=isbs=ilex=revs=aborts=0;
     
-    if ( (popt_.multihyp_mode) && (popt_.modear == 3) ) {
+    if ( (popt_.multihyp_mode) && (popt_.modear == ARMODE_FIXHOLD) ) { /* multihypothesis mode on */
         
         rtk_multi = rtk_multi_init_fxhr(popt_);
         rtk       = rtk_multi->rtk_out;
         assert( rtk_multi_is_valid_fxhr(rtk_multi) );
     }
-    else {
+    else { /* multihypothesis mode on */
         
         rtk = rtk_init(&popt_);
     }
@@ -1235,11 +1235,11 @@ static int execses(gtime_t ts, gtime_t te, double ti, const prcopt_t *popt,
     /* free obs and nav data */
     freeobsnav(&obss,&navs);
     
-    if ( (popt_.multihyp_mode) && (popt_.modear == 3) ) {
+    if ( (popt_.multihyp_mode) && (popt_.modear == ARMODE_FIXHOLD) ) { /* multihypothesis mode on */
         
         rtk_multi_free(rtk_multi);
     }
-    else {
+    else { /* multihypothesis mode on */
      
         rtk_free(rtk);
     }

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -422,7 +422,7 @@ static void procpos(FILE *fp, FILE *fptm, const prcopt_t *popt, const solopt_t *
     sol_t sol={{0}},oldsol={{0}},newsol={{0}};
     obsd_t obs[MAXOBS*2]; /* for rover and base */
     double rb[3]={0};
-    int rtk_status = 0;
+    int rtk_status = 1;
     int i,nobs,n,solstatic,num=0,pri[]={0,1,2,3,4,5,1,6};
     rtk_input_data_t *rtk_input_data = malloc(sizeof(rtk_input_data_t));
     

--- a/src/postpos.c
+++ b/src/postpos.c
@@ -478,9 +478,9 @@ static void procpos(FILE *fp, FILE *fptm, const prcopt_t *popt, const solopt_t *
                         invalidtm[nitm++] = rtk->sol.eventime;
                     }
                 }
-                outsolstat(rtk, &navs);
                 continue;
             }
+            outsolstat(rtk, &navs);
         }
  
         /* todo: repair and/or test combined mode for multihypothesis estimation */

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -211,6 +211,8 @@ const prcopt_t prcopt_default={ /* defaults processing options */
     0,                          /* base-multi_epoch */ 
 
     0, 5, 0.2, 0.5, 0.05,       /* resid-mode, resid-maxiter, resid-reset_fix, resid-reset_float, resid-block_fix_sat */
+    
+    0,                          /* multihyp-mode */
 
     {30.0,0.03,0.3},            /* std[] */
     {1E-4,1E-3,1E-4,1E-1,1E-2,0.0}, /* prn[] */

--- a/src/rtkcmn.c
+++ b/src/rtkcmn.c
@@ -210,7 +210,7 @@ const prcopt_t prcopt_default={ /* defaults processing options */
     
     0,                          /* base-multi_epoch */ 
 
-    0, 5, 0.2, 0.5, 0.05,       /* resid-mode, resid-maxiter, resid-reset_fix, resid-reset_float, resid-block_fix_sat */
+    0, 2, 0.2, 0.5, 0.05,       /* resid-mode, resid-maxiter, resid-reset_fix, resid-reset_float, resid-block_fix_sat */
     
     0,                          /* multihyp-mode */
 

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1152,6 +1152,8 @@ typedef struct {        /* processing options type */
     double residual_reset_float;  /* carrier-phase residual threshold to reset phase-bias when solution status is FLOAT (m) */
     double residual_block_fix_sat;/* carrier-phase residual threshold to prevent using a satellite for ambiguity resolution (m) */
     
+    int    multihyp_mode; /* on/off */
+    
     double std[3];      /* initial-state std [0]bias,[1]iono [2]trop */
     double prn[6];      /* process-noise std [0]bias,[1]iono [2]trop [3]acch [4]accv [5] pos */
     double sclkstab;    /* satellite clock stability (sec/sec) */
@@ -1929,6 +1931,13 @@ EXPORT int  rtkpos (rtk_t *rtk, const obsd_t *obs, int nobs, const nav_t *nav);
 EXPORT int  rtkopenstat(const char *file, int level);
 EXPORT void rtkclosestat(void);
 EXPORT int  rtkoutstat(rtk_t *rtk, char *buff);
+
+extern void outsolstat(rtk_t *rtk,const nav_t *nav);
+
+extern rtk_t *rtk_init(const prcopt_t *opt);
+extern void rtk_free(rtk_t *rtk);
+extern void rtk_copy(const rtk_t *rtk_source, rtk_t *rtk_destination);
+extern int rtk_is_valid(const rtk_t *rtk);
 
 /* precise point positioning -------------------------------------------------*/
 EXPORT void pppos(rtk_t *rtk, const obsd_t *obs, int n, const nav_t *nav);

--- a/src/rtklib.h
+++ b/src/rtklib.h
@@ -1311,6 +1311,8 @@ typedef struct {        /* RTK control/result type */
     prcopt_t opt;       /* processing options */
     int initial_mode;   /* initial positioning mode */
     smoothing_data_t smoothing_data; /* data related to smoothing of code */
+    int is_alternative_fix_possible;
+    sol_t sol_alternative;          
 } rtk_t;
 
 typedef struct half_cyc_tag {  /* half-cycle correction list type */

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -2402,11 +2402,15 @@ static int rtk_estimate_iterative(rtk_t *rtk, const obsd_t *obsd, int n_obsd, co
     if ( maxiter <= 0 ) maxiter = 1;
     
     rtk_trial = rtk_init(&rtk->opt);
-    if ( !rtk_trial ) return 0;
+    if ( !rtk_is_valid(rtk_trial) ) {
+        
+        return 0;
+    }
     rtk_trial_prev = rtk_init(&rtk->opt);
-    if ( !rtk_trial_prev ) { 
-        rtk_free(rtk_trial); 
-        return 0; 
+    if ( !rtk_is_valid(rtk_trial_prev) ) {
+        
+        rtk_free(rtk_trial);
+        return 0;
     }
     
     for (i = 0; i < maxiter; i++) {
@@ -2414,6 +2418,7 @@ static int rtk_estimate_iterative(rtk_t *rtk, const obsd_t *obsd, int n_obsd, co
         rtk_copy(rtk, rtk_trial);
         stat = estimator(rtk_trial, obsd, n_obsd, nav);
         if ( stat == 0 ) break;
+        if ( i == (maxiter-1) ) break;                            /* last iteration */
         if ( !reestimation_modifier(rtk, rtk_trial) ) break;      /* modify some rtk struct fields to produce reestimation;
                                                                      break if no modifications applied */
         rtk_copy(rtk_trial, rtk_trial_prev);

--- a/src/rtkpos.c
+++ b/src/rtkpos.c
@@ -2496,6 +2496,9 @@ extern void rtkinit(rtk_t *rtk, const prcopt_t *opt)
             rtk->ssat[sat].no_fix[freq]   = 0;
         }
     }
+    
+    rtk->is_alternative_fix_possible = 0;
+    rtk->sol_alternative = sol0;
 }
 /* free rtk control ------------------------------------------------------------
 * free memory for rtk control struct

--- a/src/rtksvr.c
+++ b/src/rtksvr.c
@@ -939,6 +939,116 @@ static void obs_queue_get_projection(obs_queue_t *obs_queue, obs_t *obs_destinat
 
 /* -------------------------------------------------------------------------- */
 
+static rtk_input_data_t *rtksvr_get_input_data(rtksvr_t *svr, int rover_data_index)
+{
+    int i, n_obsd, n_rover, n_base;
+    obsd_t *obsd;
+    double maxage = svr->rtk.opt.maxtdiff;
+    int    navsys = svr->rtk.opt.navsys;
+    gtime_t time_rover;
+    rtk_input_data_t *rtk_input_data;
+    
+    assert( svr != NULL );
+    assert( rover_data_index >= 0 );
+    assert( rover_data_index < MAXOBSBUF );
+    
+    obsd = malloc(sizeof(obsd_t) * MAXOBS * 2);
+    if ( obsd == NULL ) {
+        
+        return NULL;
+    }
+    rtk_input_data = malloc(sizeof(rtk_input_data_t));
+    if ( rtk_input_data == NULL ) {
+        
+        free(obsd);
+        return NULL;
+    }
+    
+    /* load rover data */
+    n_rover = svr->obs[0][rover_data_index].n;
+    assert( n_rover <= MAXOBS );
+    for (i = 0; i < n_rover; i++) {
+        
+        obsd[i] = svr->obs[0][rover_data_index].data[i];
+    }
+    
+    /* get optimal base obs from the queue to svr->obs[1][0] */
+    if ( svr->rtk.opt.base_multi_epoch ) {
+        
+        time_rover = obs_get_time(&svr->obs[0][rover_data_index]);
+        obs_queue_get_projection(svr->base_queue, &svr->obs[1][0], navsys, time_rover, maxage);
+    }
+    /* load base data */
+    n_base = svr->obs[1][0].n;
+    assert( n_base <= MAXOBS );
+    for (i = 0; i < n_base; i++) {
+        
+        obsd[i + n_rover] = svr->obs[1][0].data[i];
+    }
+    
+    n_obsd = n_rover + n_base;
+    
+    /* carrier phase bias correction */
+    if ( !strstr(svr->rtk.opt.pppopt, "-DIS_FCB") ) {
+        
+        corr_phase_bias(obsd, n_obsd, &svr->nav);
+    }
+    
+    rtk_input_data->obsd   = obsd;
+    rtk_input_data->n_obsd = n_obsd;
+    rtk_input_data->nav    = &svr->nav;
+    
+    return rtk_input_data;
+}
+
+static int rtksvr_compute_solution(rtksvr_t *svr, int rover_data_index, rtk_t *rtk)
+{
+    rtk_input_data_t *rtk_input_data;
+    
+    
+    assert( svr != NULL );
+    assert( rover_data_index >= 0 );
+    assert( rover_data_index < MAXOBSBUF );
+    
+    rtk_input_data = rtksvr_get_input_data(svr, rover_data_index);
+    
+    if ( rtk_input_data == NULL ) {
+        
+        return 0;
+    }
+    
+    /* rtk positioning */
+    rtkpos(rtk, rtk_input_data->obsd, rtk_input_data->n_obsd, rtk_input_data->nav);
+    
+    return 1;
+}
+
+static int rtksvr_compute_solution_multi(rtksvr_t *svr, int rover_data_index, rtk_multi_t *rtk_multi)
+{
+    rtk_input_data_t *rtk_input_data;
+    
+    assert( svr != NULL );
+    assert( rover_data_index >= 0 );
+    assert( rover_data_index < MAXOBSBUF );
+    
+    rtk_input_data = rtksvr_get_input_data(svr, rover_data_index);
+    
+    if ( rtk_input_data == NULL ) {
+        
+        return 0;
+    }
+    
+    /* update processing options (including base position) */
+    rtk_multi->opt = svr->rtk.opt;
+    memcpy(rtk_multi->opt.rb, svr->rtk.rb, sizeof(double) * 3);
+    
+    /* rtk positioning */
+    rtk_multi_estimate(rtk_multi, &rtk_multi_strategy_fxhr, rtk_input_data);
+    assert( rtk_multi_is_valid_fxhr(rtk_multi) );
+    
+    return 1;
+}
+
 /* rtk server thread ---------------------------------------------------------*/
 #ifdef WIN32
 static DWORD WINAPI rtksvrthread(void *arg)
@@ -954,20 +1064,19 @@ static void *rtksvrthread(void *arg)
     unsigned int tick,ticknmea,tick1hz,tickreset;
     unsigned char *p,*q;
     char msg[128];
-    int i,j,n,fobs[3]={0},cycle,cputime, stream_number;
-    gtime_t time_base, time_rover, time_last;
+    int i,n,fobs[3]={0},cycle,cputime, stream_number;
     double maxage = svr->rtk.opt.maxtdiff;
     int    navsys = svr->rtk.opt.navsys;
+    gtime_t time_base, time_rover, time_last;
     int ntrip_single_required = 0;
-    rtk_input_data_t *rtk_input_data = malloc(sizeof(rtk_input_data_t));
+    rtk_t *rtk_tmp = rtk_init(&svr->rtk.opt);
 
     /* This "fake" solution structure is passed to strsendnmea
      * when inpstr2-nmeareq is set to latlon*/
     sol_t latlon_sol={{0}};
     latlon_sol.stat=SOLQ_SINGLE;
     latlon_sol.time=utc2gpst(timeget());
-    for (i=0;i<3;i++)
-        latlon_sol.rr[i]=svr->nmeapos[i];
+    for (i=0;i<3;i++) latlon_sol.rr[i]=svr->nmeapos[i];
 
     tracet(3,"rtksvrthread:\n");
 
@@ -980,8 +1089,9 @@ static void *rtksvrthread(void *arg)
         ntrip_single_required = 1;
     }
 
-    for (cycle=0;svr->state;cycle++) {
-        tick=tickget();
+    for (cycle = 0; svr->state; cycle++) {
+        
+        tick = tickget();
 
         for (stream_number = 0; stream_number < N_INPUTSTR; stream_number++) {
             p = svr->buff[stream_number] + svr->nb[stream_number];
@@ -1011,21 +1121,19 @@ static void *rtksvrthread(void *arg)
         rtksvrlock(svr);
 
         for (stream_number = 0; stream_number < N_INPUTSTR; stream_number++) {
-            if (svr->format[stream_number] == STRFMT_SP3 ||
-                svr->format[stream_number] == STRFMT_RNXCLK)
-            {
+            if (svr->format[stream_number] == STRFMT_SP3
+             || svr->format[stream_number] == STRFMT_RNXCLK) {
                 /* decode download file */
                 decodefile(svr, stream_number);
             }
-            else
-            {
+            else {
                 /* decode receiver raw/rtcm data */
                 fobs[stream_number] = decoderaw(svr, stream_number);
             }
         }
 
         while ( (fobs[0] > 0) && (svr->obs[0][fobs[0]-1].n <= 0) ) { /* skip empty rover obs */
-                
+            
             fobs[0]--;
         }
         while ( (fobs[1] > 0) && (svr->obs[1][fobs[1]-1].n <= 0) ) { /* skip empty base obs */
@@ -1062,73 +1170,36 @@ static void *rtksvrthread(void *arg)
             }
         }
         
-        for (i=0;i<fobs[0];i++) { /* for each rover observation data */
-            
-            obs.n=0;
-            /* load rover data */
-            for (j=0;j<svr->obs[0][i].n&&obs.n<MAXOBS*2;j++) {
-                obs.data[obs.n++]=svr->obs[0][i].data[j];
-            }
-            if ( obs.n <= 0 ) continue; 
-            
-            /* get optimal base obs from the queue to svr->obs[1][0] */
-            if ( svr->rtk.opt.base_multi_epoch ) {
-                time_rover = obs_get_time(&svr->obs[0][i]);
-                obs_queue_get_projection(svr->base_queue, &svr->obs[1][0], navsys, time_rover, maxage);
-            }
-            /* load base data */
-            for (j=0;j<svr->obs[1][0].n&&obs.n<MAXOBS*2;j++) {
-                obs.data[obs.n++]=svr->obs[1][0].data[j];
-            }
-            /* carrier phase bias correction */
-            if (!strstr(svr->rtk.opt.pppopt,"-DIS_FCB")) {
-                corr_phase_bias(obs.data,obs.n,&svr->nav);
-            }
-            /* rtk positioning */
+        for (i = 0; i < fobs[0]; i++) { /* for each rover observation data */
+
             if ( (svr->rtk.opt.multihyp_mode) && (svr->rtk.opt.modear == ARMODE_FIXHOLD) ) { /* multihypothesis mode on */
-            
-                rtk_input_data->obsd = obs.data;
-                rtk_input_data->n_obsd = obs.n;
-                rtk_input_data->nav = &svr->nav;
                 
-                rtk_multi->opt = svr->rtk.opt;
-                memcpy(rtk_multi->opt.rb, svr->rtk.rb, sizeof(double) * 3);
-                
-                rtk_multi_estimate(rtk_multi, &rtk_multi_strategy_fxhr, rtk_input_data);
-                assert( rtk_multi_is_valid_fxhr(rtk_multi) );
-                
+                rtksvr_compute_solution_multi(svr, i, rtk_multi);
                 rtk_copy(rtk_multi->rtk_out, &svr->rtk);
                 svr->rtk.opt = rtk_multi->opt;
             }
             else { /* multihypothesis mode off */
                 
-                rtkpos(&svr->rtk,obs.data,obs.n,&svr->nav);
+                rtksvr_compute_solution(svr, i, &svr->rtk); 
             }
-
-            if (svr->rtk.sol.stat!=SOLQ_NONE) {
+            
+            if ( svr->rtk.sol.stat != SOLQ_NONE ) {
 
                 /* adjust current time */
-                tt=(int)(tickget()-tick)/1000.0+DTTOL;
-                timeset(gpst2utc(timeadd(svr->rtk.sol.time,tt)));
+                tt = (int) (tickget() - tick) / 1000.0 + DTTOL;
+                timeset(gpst2utc(timeadd(svr->rtk.sol.time, tt)));
 
                 /* write solution */
-                writesol(svr,i);
-            }
-            /* if cpu overload, inclement obs outage counter and break */
-            if ((int)(tickget()-tick)>=svr->cycle) {
-                svr->prcout+=fobs[0]-i-1;
-#if 0 /* omitted v.2.4.1 */
-                break;
-#endif
+                writesol(svr, i);
             }
         }
         
         rtksvrunlock(svr);
         
         /* send null solution if no solution (1hz) */
-        if (svr->rtk.sol.stat==SOLQ_NONE&&(int)(tick-tick1hz)>=1000) {
-            writesol(svr,0);
-            tick1hz=tick;
+        if ( (svr->rtk.sol.stat == SOLQ_NONE) && ((int) (tick - tick1hz) >= 1000) ) {
+            writesol(svr, 0);
+            tick1hz = tick;
         }
         /* write periodic command to input stream */
         for (i=0;i<N_INPUTSTR;i++) {
@@ -1142,8 +1213,9 @@ static void *rtksvrthread(void *arg)
         if ((cputime=(int)(tickget()-tick))>0) svr->cputime=cputime;
 
         /* sleep until next cycle */
-        sleepms(svr->cycle-cputime);
+        sleepms(svr->cycle - cputime);
     }
+    
     for (i=0;i<MAXSTRRTK;i++) strclose(svr->stream+i);
     for (i=0;i<N_INPUTSTR;i++) {
         svr->nb[i]=svr->npb[i]=0;
@@ -1156,8 +1228,8 @@ static void *rtksvrthread(void *arg)
         svr->nsb[i]=0;
         free(svr->sbuf[i]); svr->sbuf[i]=NULL;
     }
-    
-    free(rtk_input_data);
+
+    free(rtk_tmp);
     
     return 0;
 }


### PR DESCRIPTION
The feature provides:
* a basic API for development of variations of multi-hypothesis kalman filter
* 'fix-and-hold refinement' strategy ('fix' and 'float' filter in parallel) decreasing 
the influence of false fixes on the solution

Note: a new rtkrcv/rnx2rtkp config option to enable/disable the feature
multihyp-mode =on     # (0:off, 1:on) default=off